### PR TITLE
Improve canonical number regex

### DIFF
--- a/app.py
+++ b/app.py
@@ -47,8 +47,16 @@ def canonical_num(value: str) -> str | None:
     if not isinstance(value, str):
         return None
     s = value.translate(_DIGIT_TRANS)
-    m = __import__("re").search(r"\d+(?:[./]\d+)*", s)
-    return m.group(0) if m else None
+    re_mod = __import__("re")
+    m = re_mod.search(r"\d+(?:[./]+[^\d]*\d+)*", s)
+    if not m:
+        return None
+    digits = re_mod.findall(r"\d+", m.group(0))
+    seps = re_mod.findall(r"[./]+", m.group(0))
+    result = digits[0]
+    for sep, d in zip(seps, digits[1:]):
+        result += sep[0] + d
+    return result
 
 
 def load_law_articles(dir_path: str = "output") -> dict[str, dict[str, str]]:

--- a/interface.py
+++ b/interface.py
@@ -49,8 +49,15 @@ def canonical_num(value: str) -> str | None:
     if not isinstance(value, str):
         return None
     s = value.translate(_DIGIT_TRANS)
-    m = re.search(r"\d+(?:[./]\d+)*", s)
-    return m.group(0) if m else None
+    m = re.search(r"\d+(?:[./]+[^\d]*\d+)*", s)
+    if not m:
+        return None
+    digits = re.findall(r"\d+", m.group(0))
+    seps = re.findall(r"[./]+", m.group(0))
+    result = digits[0]
+    for sep, d in zip(seps, digits[1:]):
+        result += sep[0] + d
+    return result
 
 
 def load_law_articles(dir_path: str = "output") -> dict[str, dict[str, str]]:

--- a/ner.py
+++ b/ner.py
@@ -102,8 +102,15 @@ def _canonical_number(text: str) -> str | None:
     if not isinstance(text, str):
         return None
     s = text.translate(_DIGIT_TRANS)
-    m = re.search(r"\d+(?:[./]\d+)*", s)
-    return m.group(0) if m else None
+    m = re.search(r"\d+(?:[./]+[^\d]*\d+)*", s)
+    if not m:
+        return None
+    digits = re.findall(r"\d+", m.group(0))
+    seps = re.findall(r"[./]+", m.group(0))
+    num = digits[0]
+    for sep, d in zip(seps, digits[1:]):
+        num += sep[0] + d
+    return num
 
 
 def _parse_date(text: str) -> str | None:


### PR DESCRIPTION
## Summary
- handle numbers with letters or extra slashes when normalising
- update canonical number helpers in the web app and interface

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6865686ef1208324b78037de286068b9