### PR TITLE
Preserve referenced articles

### DIFF
--- a/ner.py
+++ b/ner.py
@@ -471,6 +471,14 @@ def expand_article_lists(text: str, result: Dict[str, Any]) -> None:
 def _remove_overlapping_articles(result: Dict[str, Any]) -> None:
     """Remove ARTICLE entities fully contained in INTERNAL_REF spans."""
     entities = result.get("entities", [])
+    relations = result.get("relations", [])
+
+    referenced = {
+        str(r.get("target_id"))
+        for r in relations
+        if r.get("type") == "refers_to"
+    }
+
     ref_ranges = [
         (
             int(e.get("start_char", -1)),
@@ -481,20 +489,34 @@ def _remove_overlapping_articles(result: Dict[str, Any]) -> None:
     ]
     if not ref_ranges:
         return
-    
+
     cleaned: list[dict] = []
+    removed_ids: set[str] = set()
     for e in entities:
         start = int(e.get("start_char", -1))
         end = int(e.get("end_char", -1))
         if e.get("type") == "ARTICLE":
+            ent_id = str(e.get("id", ""))
+            if ent_id in referenced:
+                cleaned.append(e)
+                continue
             text = str(e.get("text", ""))
             nums = re.findall(r"[0-9٠-٩]+", text.translate(_DIGIT_TRANS))
             contained = any(rs <= start and end <= re for rs, re in ref_ranges)
             overlaps = any(not (end <= rs or start >= re) for rs, re in ref_ranges)
             if contained or (len(nums) > 1 and overlaps):
+                removed_ids.add(ent_id)
                 continue
         cleaned.append(e)
     result["entities"] = cleaned
+
+    if removed_ids:
+        result["relations"] = [
+            r
+            for r in relations
+            if str(r.get("source_id")) not in removed_ids
+            and str(r.get("target_id")) not in removed_ids
+        ]
 
 
 def remove_articles_inside_dates(result: Dict[str, Any]) -> None:


### PR DESCRIPTION
## Summary
- keep ARTICLES referenced by `refers_to` relations
- drop relations when their ARTICLE target is removed
- ensure article '1' is extracted from `الفصول` lists

## Testing
- `python -m py_compile ner.py`
- `python - <<'PY'
from ner import postprocess_result
text = "الفصول: 1، 3، 4، 6، 7، 25، 29، 37"
res={'entities': [], 'relations': []}
postprocess_result(text, res)
print('ARTICLE IDs:', [e['text'] for e in res['entities'] if e['type']=='ARTICLE'])
PY`

------
https://chatgpt.com/codex/tasks/task_e_6865b707644483248003740b8892538c