### PR TITLE
Handle plural chapter and article references

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,6 +1,7 @@
 import os
 import html
 import json
+import re
 import tempfile
 import pandas as pd
 from flask import Flask, render_template, request
@@ -202,6 +203,14 @@ def index():
                     tgt_ent = id_to_ent.get(str(tgt))
                     if tgt_ent and tgt_ent.get('type') == 'ARTICLE':
                         num = canonical_num(tgt_ent.get('normalized') or tgt_ent.get('text'))
+                        if not num:
+                            continue
+                        art_txt = article_texts.get(num, '')
+                        lines.append(f"الفصل {num}<br/>{art_txt}")
+                if not lines:
+                    ref_text = str(ent.get('normalized') or ent.get('text') or '')
+                    for raw in re.findall(r'[0-9٠-٩]+', ref_text):
+                        num = canonical_num(raw)
                         if not num:
                             continue
                         art_txt = article_texts.get(num, '')

--- a/interface.py
+++ b/interface.py
@@ -272,6 +272,14 @@ if uploaded and st.button("Extract Entities"):
                     continue
                 art_txt = article_popup_texts.get(num, "")
                 lines.append(f"الفصل {num}<br/>{art_txt}")
+        if not lines:
+            ref_text = str(ent.get("normalized") or ent.get("text") or "")
+            for raw in re.findall(r"[0-9٠-٩]+", ref_text):
+                num = canonical_num(raw)
+                if not num:
+                    continue
+                art_txt = article_popup_texts.get(num, "")
+                lines.append(f"الفصل {num}<br/>{art_txt}")
         if lines:
             ref_article_texts[f"ID_{ent.get('id')}"] = "<br/><br/>".join(lines)
     article_popup_texts.update(ref_article_texts)


### PR DESCRIPTION
## Summary
- normalize plural references like `الفصول` to use the singular heading

## Testing
- `python -m py_compile app.py interface.py ner.py`


------
https://chatgpt.com/codex/tasks/task_e_68660b047690832496619248efff9ed1