### PR TITLE
Add marker-based annotation support

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,10 @@ python ner.py --input path/to/text.txt --output_dir ner_out
 ```
 This creates entities.csv and relations.csv inside the output directory. Using a PDF file as input triggers automatic OCR.
 
+Pass `--annotate_text` to also save a copy of the input text where entity spans
+are wrapped in `[[ENT …]]` markers. The Streamlit and Flask interfaces accept
+such marked files and will highlight the entities without re-running the model.
+
 # Court decision parser
 ```bash
 python decision_parser.py --input path/to/decision.pdf --output decision.json

--- a/highlight.py
+++ b/highlight.py
@@ -4,6 +4,14 @@ from __future__ import annotations
 
 import html
 
+try:  # Allow using within package or standalone
+    from .ner import parse_marked_text  # type: ignore
+except Exception:  # pragma: no cover - fallback
+    try:
+        from ner import parse_marked_text  # type: ignore
+    except Exception:
+        parse_marked_text = None
+
 _DIGIT_TRANS = str.maketrans("٠١٢٣٤٥٦٧٨٩", "0123456789")
 
 
@@ -29,13 +37,18 @@ def canonical_num(value: str) -> str | None:
 
 def highlight_text(
     text: str,
-    entities: list[dict],
+    entities: list[dict] | None = None,
     article_map: dict[str, str] | None = None,
     ref_targets: dict[str, list[str]] | None = None,
     tooltips: dict[str, str] | None = None,
     article_texts: dict[str, str] | None = None,
 ) -> str:
     """Return HTML for *text* with entity spans highlighted."""
+    if "[[ENT" in text and parse_marked_text is not None:
+        text, parsed = parse_marked_text(text)
+        entities = parsed
+    if entities is None:
+        entities = []
     popup = (
         '<div id="article-popup" style="display:none;position:fixed;top:10%;'
         "left:10%;width:80%;max-height:80%;overflow:auto;background-color:white;"


### PR DESCRIPTION
## Summary
- implement functions in `ner.py` to mark entity spans inside text and parse the markers back to offsets
- allow saving annotated text from the `ner.py` CLI
- update `highlight.highlight_text` to accept such marked text
- update Streamlit and Flask interfaces to load already annotated files
- document the new workflow in the README

## Testing
- `python -m py_compile highlight.py ner.py interface.py app.py`

------
https://chatgpt.com/codex/tasks/task_e_686c385f7568832493a5b4730ceeb444