### PR TITLE
Add SQL query interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,3 +97,16 @@ To inspect cross-document references you can export the relation graph:
 python import_db.py --export-graph relations.graphml --db legislation.db
 ```
 Load the generated GraphML file in networkx or Gephi for further analysis.
+
+## Querying the database from the UI
+
+Both the Flask and Streamlit interfaces include a page to run read‑only SQL
+statements. Start the web app and open `/query` (Flask) or use the "SQL Query"
+section in the Streamlit interface. Choose one of the predefined statements or
+enter a custom query and the results will be displayed in a table.
+
+Example using the built‑in query:
+
+```sql
+SELECT doc_type, COUNT(*) FROM Documents GROUP BY doc_type;
+```

--- a/templates/home.html
+++ b/templates/home.html
@@ -9,5 +9,6 @@
     <h1>Legal Processing Portal</h1>
     <p><a href="{{ url_for('index') }}">Extract Entities</a></p>
     <p><a href="{{ url_for('parse_decision_route') }}">Parse Court Decision</a></p>
+    <p><a href="{{ url_for('run_query') }}">Run SQL Query</a></p>
 </body>
 </html>

--- a/templates/query.html
+++ b/templates/query.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8" />
+    <title>SQL Query</title>
+    <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}"/>
+    <script>
+        const presets = {{ queries|tojson }};
+        function setPreset(sel) {
+            const q = presets[sel.value] || '';
+            document.getElementById('sql').value = q;
+        }
+    </script>
+</head>
+<body>
+    <h1>Run SQL Query</h1>
+    <form method="post">
+        <label>Predefined:
+            <select id="preset" onchange="setPreset(this)">
+                <option value="">Custom...</option>
+                {% for name in queries.keys() %}
+                <option value="{{ name }}">{{ name }}</option>
+                {% endfor %}
+            </select>
+        </label>
+        <br/>
+        <textarea id="sql" name="sql" rows="6" cols="80">{{ sql }}</textarea><br/>
+        <button type="submit">Execute</button>
+    </form>
+    {% if error %}
+    <p style="color:red;">{{ error }}</p>
+    {% endif %}
+    {% if result_html %}
+        <h2>Results</h2>
+        <div>{{ result_html|safe }}</div>
+    {% endif %}
+</body>
+</html>


### PR DESCRIPTION
## Summary
- connect to imported SQLite database
- expose `/query` Flask route with dropdown for SQL presets
- add Streamlit section to execute read-only SQL queries
- link query page from home
- document the feature in README

## Testing
- `python -m py_compile app.py interface.py import_db.py`

------
https://chatgpt.com/codex/tasks/task_e_686d80bf7dbc83249467f476aa7227cf