### PR TITLE
Improve prompt loading for standalone pipeline scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,23 @@ python gpt.py --input path/to/document.pdf --output_dir output
 ```
 If the input is a PDF it is OCRed first. The result is a JSON file (<document>.json) describing the legislation’s structure. A different model can be selected using --model.
 
+## Multi-step pipeline
+The scripts in `pipeline/` expose the same functionality as a series of steps. Use these when you need finer control over intermediate files:
+
+```bash
+# Extract structure in two passes
+python -m pipeline.extract_chunks --input path/to/text.txt --output structure_raw.json --model gpt-4o
+
+# Post-process the raw output
+python -m pipeline.post_process --input structure_raw.json --output structure_final.json
+
+# Run the entire process in one command
+python -m pipeline.run_pipeline --input path/to/document.pdf --output_dir output
+```
+Running them with `-m` ensures relative imports resolve correctly when executed from the repository root.
+You can also call the scripts directly, e.g. `python pipeline/extract_chunks.py`,
+as they automatically locate the shared `prompts` folder.
+
 # Named‑entity extraction
 ```bash
 python ner.py --input path/to/text.txt --output_dir ner_out

--- a/pipeline/extract_chunks.py
+++ b/pipeline/extract_chunks.py
@@ -6,7 +6,13 @@ import re
 
 import tiktoken
 
-from . import gpt_helpers as gpt
+try:  # Prefer relative import when running as a package
+    from . import gpt_helpers as gpt
+except Exception:  # Allow running as a script
+    try:
+        import gpt_helpers as gpt  # type: ignore
+    except Exception as exc:  # pragma: no cover - missing dependency
+        raise ImportError("gpt_helpers module is required") from exc
 
 
 def run_passes(txt_path: str, model: str) -> dict:

--- a/pipeline/gpt_helpers.py
+++ b/pipeline/gpt_helpers.py
@@ -49,7 +49,19 @@ def adjust_for_model(name: str) -> None:
 # ------------------------------------------------------------
 
 def load_prompts() -> tuple[str, str]:
-    base = os.path.join(os.path.dirname(__file__), "prompts")
+    """Return the contents of prompt_1.txt and prompt_2.txt.
+
+    When the pipeline modules are executed directly, the current file lives
+    inside ``pipeline/`` while the prompts folder sits at the repository
+    root. We therefore try ``pipeline/prompts`` first and fall back to the
+    parent directory if the files are missing.
+    """
+
+    here = os.path.dirname(__file__)
+    base = os.path.join(here, "prompts")
+    if not os.path.exists(os.path.join(base, "prompt_1.txt")):
+        base = os.path.join(here, "..", "prompts")
+
     with open(os.path.join(base, "prompt_1.txt"), "r", encoding="utf-8") as f1:
         p1 = f1.read()
     with open(os.path.join(base, "prompt_2.txt"), "r", encoding="utf-8") as f2:

--- a/pipeline/post_process.py
+++ b/pipeline/post_process.py
@@ -3,7 +3,13 @@ import sys
 import json
 import argparse
 
-from . import gpt_helpers as gpt
+try:  # Prefer relative import when running as a package
+    from . import gpt_helpers as gpt
+except Exception:  # Allow running as a script
+    try:
+        import gpt_helpers as gpt  # type: ignore
+    except Exception as exc:  # pragma: no cover - missing dependency
+        raise ImportError("gpt_helpers module is required") from exc
 
 
 def finalize_from_file(raw_json_path: str, output_path: str) -> None:

--- a/pipeline/run_pipeline.py
+++ b/pipeline/run_pipeline.py
@@ -2,9 +2,17 @@ import argparse
 import os
 import json
 
-from .ocr_to_text import convert_to_text
-from .extract_chunks import run_passes
-from .post_process import finalize_from_file
+try:  # Prefer relative imports when running as a package
+    from .ocr_to_text import convert_to_text
+    from .extract_chunks import run_passes
+    from .post_process import finalize_from_file
+except Exception:  # Allow running as a script
+    try:
+        from ocr_to_text import convert_to_text  # type: ignore
+        from extract_chunks import run_passes  # type: ignore
+        from post_process import finalize_from_file  # type: ignore
+    except Exception as exc:  # pragma: no cover - missing dependency
+        raise ImportError("pipeline modules are required") from exc
 
 
 def run_pipeline(input_path: str, output_dir: str, model: str) -> str:


### PR DESCRIPTION
## Summary
- allow pipeline scripts to locate prompts when run directly
- note that pipeline modules can be called directly

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6883b471a8688324af1437db7d51c3a8