### PR TITLE
Fix flexible legislation hierarchy

### DIFF
--- a/pipeline/post_process.py
+++ b/pipeline/post_process.py
@@ -30,6 +30,7 @@ def finalize_from_file(raw_json_path: str, output_path: str) -> None:
     gpt.drop_empty_non_article_nodes(structure_tree)
     gpt.fill_missing_articles(structure_tree)
     gpt.fill_missing_sections(structure_tree)
+    gpt.drop_empty_non_article_nodes(structure_tree)
     gpt.finalize_structure(structure_tree)
     gpt.sort_sections(structure_tree)
     gpt.remove_empty_duplicate_articles(structure_tree)


### PR DESCRIPTION
## Summary
- maintain hierarchical rank order using canonical mapping
- preserve text for all section levels
- prune placeholder nodes after filling gaps
- run same fixes in pipeline helpers

## Testing
- `python -m py_compile gpt.py pipeline/gpt_helpers.py pipeline/fix_structure.py pipeline/post_process.py`
- `python -m pipeline.post_process --input output/structure_raw.json --output output/test_final.json` *(fails: ModuleNotFoundError: No module named 'tiktoken')*

------
https://chatgpt.com/codex/tasks/task_e_688540f4c35483249d16f36ce7cc0c00