### PR TITLE
Fix stray chapter nodes in hierarchy builder

### DIFF
--- a/pipeline/hierarchy_builder.py
+++ b/pipeline/hierarchy_builder.py
@@ -197,6 +197,21 @@ def attach_stray_articles(children: List[Dict[str, Any]]) -> None:
         node_type = canonical_type(node.get("type", ""))
 
         if node_type in {"قسم", "باب", "فصل"}:
+            # Occasionally a ``فصل`` heading is emitted at the same hierarchical
+            # level as its preceding ``باب``.  When this happens we should nest
+            # the chapter under the most recent ``باب`` instead of leaving it as
+            # a sibling.  This mirrors the logic used for stray article nodes
+            # below.
+            if (
+                node_type == "فصل"
+                and last_struct is not None
+                and canonical_type(last_struct.get("type", "")) == "باب"
+            ):
+                last_struct.setdefault("children", []).append(node)
+                children.pop(i)
+                attach_stray_articles(node.get("children", []))
+                continue
+
             attach_stray_articles(node.get("children", []))
             last_struct = node
             i += 1


### PR DESCRIPTION
## Summary
- ensure stray فصل nodes following a باب are nested under the preceding باب

## Testing
- `python3 pipeline/hierarchy_builder.py --input output/structure_raw.json --output output/structure_final.json`
- `jq '.structure[] | select(.number=="5").children | map(.type)' output/structure_final.json`
- `jq '.structure[] | select(.number=="5").children[0].children | map({type:.type, number:.number})' output/structure_final.json`


------
https://chatgpt.com/codex/tasks/task_e_688e47d37c9c83249052f465f3a800d4