### PR TITLE
Add structure extraction to web interface

### DIFF
--- a/templates/home.html
+++ b/templates/home.html
@@ -8,6 +8,7 @@
 <body>
     <h1>Legal Processing Portal</h1>
     <p><a href="{{ url_for('index') }}">Extract Entities</a></p>
+    <p><a href="{{ url_for('extract_structure') }}">Extract Structure</a></p>
     <p><a href="{{ url_for('parse_decision_route') }}">Parse Court Decision</a></p>
     <p><a href="{{ url_for('run_query') }}">Run SQL Query</a></p>
 </body>

--- a/templates/structure.html
+++ b/templates/structure.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8" />
+    <title>Structure Extraction</title>
+    <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}" />
+</head>
+<body>
+    <h1>Structure Extraction</h1>
+    <form action="{{ url_for('extract_structure') }}" method="post" enctype="multipart/form-data">
+        <label>Upload PDF or text file:
+            <input type="file" name="file" required>
+        </label>
+        <label>Model:
+            <input type="text" name="model" value="gpt-3.5-turbo-16k">
+        </label>
+        <button type="submit">Build Structure</button>
+    </form>
+    {% if error %}
+        <p>{{ error }}</p>
+    {% endif %}
+    {% if result_json %}
+        <h2>Result</h2>
+        <pre>{{ result_json }}</pre>
+        <a href="data:application/json;charset=utf-8,{{ result_json | urlencode }}" download="structure.json">Download structure.json</a>
+    {% endif %}
+</body>
+</html>


### PR DESCRIPTION
## Summary
- expose chunk extraction and hierarchy building via new `/structure` endpoint
- link structure extraction page from home and provide template for results

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688e5a7103348324ad2f227dc25c3385