### PR TITLE
feat: add modern UI design

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -1,8 +1,107 @@
 body {
-    font-family: Arial, sans-serif;
-    margin: 20px;
+    font-family: 'Segoe UI', Arial, sans-serif;
+    background-color: #f4f6f9;
+    color: #333;
+    margin: 0;
 }
 
-.ner-span { direction: rtl; }
-.entity-mark { background-color: #FFFF00; }
-.entity-mark.selected { background-color: orange; }
+header {
+    background-color: #2c3e50;
+    color: #fff;
+    padding: 10px 20px;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+}
+
+header .logo {
+    font-weight: bold;
+    font-size: 1.2rem;
+}
+
+nav a {
+    color: #fff;
+    margin-right: 15px;
+    text-decoration: none;
+    font-weight: 500;
+}
+
+nav a:hover {
+    text-decoration: underline;
+}
+
+.container {
+    max-width: 900px;
+    margin: 30px auto;
+    padding: 0 15px;
+}
+
+.card {
+    background: #fff;
+    padding: 20px;
+    border-radius: 8px;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+    margin-bottom: 20px;
+}
+
+label {
+    display: block;
+    margin-top: 10px;
+}
+
+input[type="file"],
+input[type="text"],
+select,
+textarea {
+    width: 100%;
+    padding: 8px;
+    margin-top: 5px;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+}
+
+button,
+.button {
+    background-color: #3498db;
+    color: #fff;
+    border: none;
+    padding: 10px 15px;
+    margin-top: 15px;
+    border-radius: 4px;
+    cursor: pointer;
+    text-decoration: none;
+    display: inline-block;
+}
+
+button:hover,
+.button:hover {
+    background-color: #2980b9;
+}
+
+.menu {
+    list-style: none;
+    padding: 0;
+}
+
+.menu li {
+    margin: 10px 0;
+}
+
+pre {
+    background: #f5f5f5;
+    padding: 10px;
+    border-radius: 4px;
+    overflow-x: auto;
+}
+
+.ner-span {
+    direction: rtl;
+}
+
+.entity-mark {
+    background-color: #FFFF00;
+}
+
+.entity-mark.selected {
+    background-color: orange;
+}

--- a/templates/decision.html
+++ b/templates/decision.html
@@ -6,19 +6,37 @@
     <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}" />
 </head>
 <body>
+<header>
+    <div class="logo">Legal AI Assistant</div>
+    <nav>
+        <a href="{{ url_for('home') }}">Home</a>
+        <a href="{{ url_for('index') }}">Entities</a>
+        <a href="{{ url_for('extract_structure') }}">Structure</a>
+        <a href="{{ url_for('parse_decision_route') }}">Decision</a>
+        <a href="{{ url_for('run_query') }}">SQL</a>
+    </nav>
+</header>
+<main class="container">
     <h1>Court Decision Parser</h1>
-    <form action="/decision" method="post" enctype="multipart/form-data">
+    <form class="card" action="{{ url_for('parse_decision_route') }}" method="post" enctype="multipart/form-data">
         <label>Upload PDF or text file:
             <input type="file" name="file" required>
         </label>
         <label>Model:
-            <input type="text" name="model" value="gpt-3.5-turbo-16k">
+            <input list="models" name="model" value="gpt-3.5-turbo-16k">
+            <datalist id="models">
+                <option value="gpt-3.5-turbo-16k">
+                <option value="gpt-4o">
+            </datalist>
         </label>
         <button type="submit">Parse Decision</button>
     </form>
     {% if result_json %}
-        <h2>Result</h2>
-        <pre>{{ result_json }}</pre>
+        <section class="card">
+            <h2>Result</h2>
+            <pre>{{ result_json }}</pre>
+        </section>
     {% endif %}
+</main>
 </body>
 </html>

--- a/templates/home.html
+++ b/templates/home.html
@@ -6,10 +6,24 @@
     <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}"/>
 </head>
 <body>
+<header>
+    <div class="logo">Legal AI Assistant</div>
+    <nav>
+        <a href="{{ url_for('home') }}">Home</a>
+        <a href="{{ url_for('index') }}">Entities</a>
+        <a href="{{ url_for('extract_structure') }}">Structure</a>
+        <a href="{{ url_for('parse_decision_route') }}">Decision</a>
+        <a href="{{ url_for('run_query') }}">SQL</a>
+    </nav>
+</header>
+<main class="container">
     <h1>Legal Processing Portal</h1>
-    <p><a href="{{ url_for('index') }}">Extract Entities</a></p>
-    <p><a href="{{ url_for('extract_structure') }}">Extract Structure</a></p>
-    <p><a href="{{ url_for('parse_decision_route') }}">Parse Court Decision</a></p>
-    <p><a href="{{ url_for('run_query') }}">Run SQL Query</a></p>
+    <ul class="menu">
+        <li><a class="button" href="{{ url_for('index') }}">Extract Entities</a></li>
+        <li><a class="button" href="{{ url_for('extract_structure') }}">Extract Structure</a></li>
+        <li><a class="button" href="{{ url_for('parse_decision_route') }}">Parse Court Decision</a></li>
+        <li><a class="button" href="{{ url_for('run_query') }}">Run SQL Query</a></li>
+    </ul>
+</main>
 </body>
 </html>

--- a/templates/index.html
+++ b/templates/index.html
@@ -6,34 +6,52 @@
     <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}"/>
 </head>
 <body>
+<header>
+    <div class="logo">Legal AI Assistant</div>
+    <nav>
+        <a href="{{ url_for('home') }}">Home</a>
+        <a href="{{ url_for('index') }}">Entities</a>
+        <a href="{{ url_for('extract_structure') }}">Structure</a>
+        <a href="{{ url_for('parse_decision_route') }}">Decision</a>
+        <a href="{{ url_for('run_query') }}">SQL</a>
+    </nav>
+</header>
+<main class="container">
     <h1>Legal NER Assistant</h1>
-    <form action="{{ url_for('index') }}" method="post" enctype="multipart/form-data">
+    <form class="card" action="{{ url_for('index') }}" method="post" enctype="multipart/form-data">
         <label>Upload PDF or text file:
             <input type="file" name="file" required>
         </label>
         <label>Model:
-            <input type="text" name="model" value="gpt-3.5-turbo-16k">
+            <input list="models" name="model" value="gpt-3.5-turbo-16k">
+            <datalist id="models">
+                <option value="gpt-3.5-turbo-16k">
+                <option value="gpt-4o">
+            </datalist>
         </label>
         <button type="submit">Extract Entities</button>
     </form>
 
     {% if entities_table %}
-        <h2>Annotated Text</h2>
-        <div>{{ annotated|safe }}</div>
+        <section class="card">
+            <h2>Annotated Text</h2>
+            <div>{{ annotated|safe }}</div>
 
-        <h2>Entities</h2>
-        {{ entities_table|safe }}
-        <a href="data:text/csv;charset=utf-8,{{ entities_csv | urlencode }}" download="entities.csv">Download entities.csv</a>
+            <h2>Entities</h2>
+            {{ entities_table|safe }}
+            <a class="button" href="data:text/csv;charset=utf-8,{{ entities_csv | urlencode }}" download="entities.csv">Download entities.csv</a>
 
-        {% if relations_table %}
-            <h2>Relations</h2>
-            {{ relations_table|safe }}
-            <a href="data:text/csv;charset=utf-8,{{ relations_csv | urlencode }}" download="relations.csv">Download relations.csv</a>
-            {% if graph_html %}
-                <h2>Relation Graph</h2>
-                <div>{{ graph_html|safe }}</div>
+            {% if relations_table %}
+                <h2>Relations</h2>
+                {{ relations_table|safe }}
+                <a class="button" href="data:text/csv;charset=utf-8,{{ relations_csv | urlencode }}" download="relations.csv">Download relations.csv</a>
+                {% if graph_html %}
+                    <h2>Relation Graph</h2>
+                    <div>{{ graph_html|safe }}</div>
+                {% endif %}
             {% endif %}
-        {% endif %}
+        </section>
     {% endif %}
+</main>
 </body>
 </html>

--- a/templates/query.html
+++ b/templates/query.html
@@ -13,8 +13,19 @@
     </script>
 </head>
 <body>
+<header>
+    <div class="logo">Legal AI Assistant</div>
+    <nav>
+        <a href="{{ url_for('home') }}">Home</a>
+        <a href="{{ url_for('index') }}">Entities</a>
+        <a href="{{ url_for('extract_structure') }}">Structure</a>
+        <a href="{{ url_for('parse_decision_route') }}">Decision</a>
+        <a href="{{ url_for('run_query') }}">SQL</a>
+    </nav>
+</header>
+<main class="container">
     <h1>Run SQL Query</h1>
-    <form method="post">
+    <form class="card" method="post">
         <label>Predefined:
             <select id="preset" onchange="setPreset(this)">
                 <option value="">Custom...</option>
@@ -23,16 +34,22 @@
                 {% endfor %}
             </select>
         </label>
-        <br/>
-        <textarea id="sql" name="sql" rows="6" cols="80">{{ sql }}</textarea><br/>
+        <label>SQL:
+            <textarea id="sql" name="sql" rows="6">{{ sql }}</textarea>
+        </label>
         <button type="submit">Execute</button>
     </form>
     {% if error %}
-    <p style="color:red;">{{ error }}</p>
+    <section class="card" style="color:red;">
+        <p>{{ error }}</p>
+    </section>
     {% endif %}
     {% if result_html %}
-        <h2>Results</h2>
-        <div>{{ result_html|safe }}</div>
+        <section class="card">
+            <h2>Results</h2>
+            <div>{{ result_html|safe }}</div>
+        </section>
     {% endif %}
+</main>
 </body>
 </html>

--- a/templates/structure.html
+++ b/templates/structure.html
@@ -6,23 +6,43 @@
     <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}" />
 </head>
 <body>
+<header>
+    <div class="logo">Legal AI Assistant</div>
+    <nav>
+        <a href="{{ url_for('home') }}">Home</a>
+        <a href="{{ url_for('index') }}">Entities</a>
+        <a href="{{ url_for('extract_structure') }}">Structure</a>
+        <a href="{{ url_for('parse_decision_route') }}">Decision</a>
+        <a href="{{ url_for('run_query') }}">SQL</a>
+    </nav>
+</header>
+<main class="container">
     <h1>Structure Extraction</h1>
-    <form action="{{ url_for('extract_structure') }}" method="post" enctype="multipart/form-data">
+    <form class="card" action="{{ url_for('extract_structure') }}" method="post" enctype="multipart/form-data">
         <label>Upload PDF or text file:
             <input type="file" name="file" required>
         </label>
         <label>Model:
-            <input type="text" name="model" value="gpt-3.5-turbo-16k">
+            <input list="models" name="model" value="gpt-3.5-turbo-16k">
+            <datalist id="models">
+                <option value="gpt-3.5-turbo-16k">
+                <option value="gpt-4o">
+            </datalist>
         </label>
         <button type="submit">Build Structure</button>
     </form>
     {% if error %}
-        <p>{{ error }}</p>
+        <section class="card">
+            <p>{{ error }}</p>
+        </section>
     {% endif %}
     {% if result_json %}
-        <h2>Result</h2>
-        <pre>{{ result_json }}</pre>
-        <a href="data:application/json;charset=utf-8,{{ result_json | urlencode }}" download="structure.json">Download structure.json</a>
+        <section class="card">
+            <h2>Result</h2>
+            <pre>{{ result_json }}</pre>
+            <a class="button" href="data:application/json;charset=utf-8,{{ result_json | urlencode }}" download="structure.json">Download structure.json</a>
+        </section>
     {% endif %}
+</main>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- overhaul frontend styling with modern navigation, card layout, and buttons
- add model suggestions and consistent headers across entity, structure, decision, and query pages
- enhance home page with quick links for easier navigation

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688e5ccf38088324861d9b7f855335be