### PR TITLE
Integrate structure pipeline and Moroccan legislation viewer

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -105,3 +105,14 @@ pre {
 .entity-mark.selected {
     background-color: orange;
 }
+
+.json-tree ul {
+    list-style: none;
+    margin-left: 20px;
+    padding-left: 15px;
+    border-left: 1px solid #ccc;
+}
+
+.json-tree details > summary {
+    cursor: pointer;
+}

--- a/templates/decision.html
+++ b/templates/decision.html
@@ -14,6 +14,7 @@
         <a href="{{ url_for('extract_structure') }}">Structure</a>
         <a href="{{ url_for('parse_decision_route') }}">Decision</a>
         <a href="{{ url_for('run_query') }}">SQL</a>
+        <a href="{{ url_for('view_legislation') }}">Moroccan Legislation</a>
     </nav>
 </header>
 <main class="container">

--- a/templates/home.html
+++ b/templates/home.html
@@ -14,6 +14,7 @@
         <a href="{{ url_for('extract_structure') }}">Structure</a>
         <a href="{{ url_for('parse_decision_route') }}">Decision</a>
         <a href="{{ url_for('run_query') }}">SQL</a>
+        <a href="{{ url_for('view_legislation') }}">Moroccan Legislation</a>
     </nav>
 </header>
 <main class="container">
@@ -23,6 +24,7 @@
         <li><a class="button" href="{{ url_for('extract_structure') }}">Chunk &amp; Build Hierarchy</a></li>
         <li><a class="button" href="{{ url_for('parse_decision_route') }}">Parse Court Decision</a></li>
         <li><a class="button" href="{{ url_for('run_query') }}">Run SQL Query</a></li>
+        <li><a class="button" href="{{ url_for('view_legislation') }}">Moroccan Legislation</a></li>
     </ul>
 </main>
 </body>

--- a/templates/index.html
+++ b/templates/index.html
@@ -14,6 +14,7 @@
         <a href="{{ url_for('extract_structure') }}">Structure</a>
         <a href="{{ url_for('parse_decision_route') }}">Decision</a>
         <a href="{{ url_for('run_query') }}">SQL</a>
+        <a href="{{ url_for('view_legislation') }}">Moroccan Legislation</a>
     </nav>
 </header>
 <main class="container">

--- a/templates/legislation.html
+++ b/templates/legislation.html
@@ -1,0 +1,73 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8" />
+    <title>Moroccan Legislation</title>
+    <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}" />
+</head>
+<body>
+<header>
+    <div class="logo">Legal AI Assistant</div>
+    <nav>
+        <a href="{{ url_for('home') }}">Home</a>
+        <a href="{{ url_for('index') }}">Entities</a>
+        <a href="{{ url_for('extract_structure') }}">Structure</a>
+        <a href="{{ url_for('parse_decision_route') }}">Decision</a>
+        <a href="{{ url_for('run_query') }}">SQL</a>
+        <a href="{{ url_for('view_legislation') }}">Moroccan Legislation</a>
+    </nav>
+</header>
+<main class="container">
+    <h1>Moroccan Legislation</h1>
+    <section class="card">
+        <ul class="menu">
+        {% for f in files %}
+            <li><a href="{{ url_for('view_legislation', file=f) }}">{{ f }}</a></li>
+        {% else %}
+            <li>No JSON files found.</li>
+        {% endfor %}
+        </ul>
+    </section>
+    {% if data %}
+    <section class="card">
+        <h2>{{ selected }}</h2>
+        <div id="json-tree" class="json-tree"></div>
+    </section>
+    <script>
+    const data = {{ data | tojson }};
+    function render(container, obj) {
+        if (Array.isArray(obj)) {
+            const ul = document.createElement('ul');
+            obj.forEach(item => {
+                const li = document.createElement('li');
+                render(li, item);
+                ul.appendChild(li);
+            });
+            container.appendChild(ul);
+        } else if (typeof obj === 'object' && obj !== null) {
+            const ul = document.createElement('ul');
+            for (const [key, value] of Object.entries(obj)) {
+                const li = document.createElement('li');
+                if (typeof value === 'object' && value !== null) {
+                    const details = document.createElement('details');
+                    const summary = document.createElement('summary');
+                    summary.textContent = key;
+                    details.appendChild(summary);
+                    render(details, value);
+                    li.appendChild(details);
+                } else {
+                    li.textContent = key + ': ' + value;
+                }
+                ul.appendChild(li);
+            }
+            container.appendChild(ul);
+        } else {
+            container.textContent = obj;
+        }
+    }
+    render(document.getElementById('json-tree'), data);
+    </script>
+    {% endif %}
+</main>
+</body>
+</html>

--- a/templates/query.html
+++ b/templates/query.html
@@ -21,6 +21,7 @@
         <a href="{{ url_for('extract_structure') }}">Structure</a>
         <a href="{{ url_for('parse_decision_route') }}">Decision</a>
         <a href="{{ url_for('run_query') }}">SQL</a>
+        <a href="{{ url_for('view_legislation') }}">Moroccan Legislation</a>
     </nav>
 </header>
 <main class="container">

--- a/templates/structure.html
+++ b/templates/structure.html
@@ -14,6 +14,7 @@
         <a href="{{ url_for('extract_structure') }}">Structure</a>
         <a href="{{ url_for('parse_decision_route') }}">Decision</a>
         <a href="{{ url_for('run_query') }}">SQL</a>
+        <a href="{{ url_for('view_legislation') }}">Moroccan Legislation</a>
     </nav>
 </header>
 <main class="container">
@@ -36,12 +37,47 @@
             <p>{{ error }}</p>
         </section>
     {% endif %}
-    {% if result_json %}
+    {% if result %}
         <section class="card">
             <h2>Result</h2>
-            <pre>{{ result_json }}</pre>
-            <a class="button" href="data:application/json;charset=utf-8,{{ result_json | urlencode }}" download="structure.json">Download structure.json</a>
+            <div id="json-tree" class="json-tree"></div>
+            <a class="button" href="{{ url_for('view_legislation', file=saved_file) }}">Open saved file</a>
+            <a class="button" href="data:application/json;charset=utf-8,{{ result | tojson | urlencode }}" download="{{ saved_file }}">Download {{ saved_file }}</a>
         </section>
+        <script>
+        const data = {{ result | tojson }};
+        function render(container, obj) {
+            if (Array.isArray(obj)) {
+                const ul = document.createElement('ul');
+                obj.forEach(item => {
+                    const li = document.createElement('li');
+                    render(li, item);
+                    ul.appendChild(li);
+                });
+                container.appendChild(ul);
+            } else if (typeof obj === 'object' && obj !== null) {
+                const ul = document.createElement('ul');
+                for (const [key, value] of Object.entries(obj)) {
+                    const li = document.createElement('li');
+                    if (typeof value === 'object' && value !== null) {
+                        const details = document.createElement('details');
+                        const summary = document.createElement('summary');
+                        summary.textContent = key;
+                        details.appendChild(summary);
+                        render(details, value);
+                        li.appendChild(details);
+                    } else {
+                        li.textContent = key + ': ' + value;
+                    }
+                    ul.appendChild(li);
+                }
+                container.appendChild(ul);
+            } else {
+                container.textContent = obj;
+            }
+        }
+        render(document.getElementById('json-tree'), data);
+        </script>
     {% endif %}
 </main>
 </body>


### PR DESCRIPTION
## Summary
- integrate OCR-to-text, chunk extraction, and hierarchy-building into the `/structure` route, saving results to `output/`
- add Moroccan Legislation page with interactive JSON viewer for saved files and link it in site navigation
- enhance structure page with interactive JSON tree and links to the new viewer

## Testing
- `pytest -q`
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_688e6de163f08324936f5ee875282092