### PR TITLE
Enable structure pipeline without Azure credentials

### DIFF
--- a/app.py
+++ b/app.py
@@ -24,10 +24,7 @@ except Exception:  # pragma: no cover - optional dependency
     parse_decision = None
 
 try:  # Optional pipeline for structure extraction
-    if os.getenv("AZURE_ENDPOINT") and os.getenv("AZURE_KEY"):
-        from pipeline.ocr_to_text import convert_to_text
-    else:  # pragma: no cover - credentials missing
-        convert_to_text = None
+    from pipeline.ocr_to_text import convert_to_text
     from pipeline.extract_chunks import run_passes
     from pipeline.hierarchy_builder import (
         attach_stray_articles,
@@ -316,6 +313,8 @@ def extract_structure():
                 with open(out_path, 'w', encoding='utf-8') as f:
                     json.dump(result, f, ensure_ascii=False, indent=2)
                 return render_template('structure.html', result=result, saved_file=os.path.basename(out_path))
+            except Exception as exc:  # pragma: no cover - display error
+                return render_template('structure.html', error=str(exc))
             finally:
                 os.unlink(input_path)
     return render_template('structure.html')

--- a/pipeline/ocr_to_text.py
+++ b/pipeline/ocr_to_text.py
@@ -1,19 +1,25 @@
 import os
 import sys
 import argparse
-from azure.core.credentials import AzureKeyCredential
-from azure.ai.formrecognizer import DocumentAnalysisClient
+try:  # optional dependency
+    from azure.core.credentials import AzureKeyCredential
+    from azure.ai.formrecognizer import DocumentAnalysisClient
+except Exception:  # pragma: no cover - azure not installed
+    AzureKeyCredential = None
+    DocumentAnalysisClient = None
 
 AZURE_ENDPOINT = os.getenv("AZURE_ENDPOINT")
 AZURE_KEY = os.getenv("AZURE_KEY")
 
-if not AZURE_ENDPOINT or not AZURE_KEY:
-    print("❌ Missing Azure credentials. Please set the AZURE_ENDPOINT and AZURE_KEY environment variables.")
-    sys.exit(1)
-
 
 def pdf_to_arabic_text(pdf_path: str) -> str:
     """Use Azure Form Recognizer to OCR a PDF and return all Arabic text."""
+    if DocumentAnalysisClient is None or AzureKeyCredential is None:
+        raise RuntimeError("Azure Form Recognizer client is not available")
+    if not AZURE_ENDPOINT or not AZURE_KEY:
+        raise RuntimeError(
+            "Missing Azure credentials. Please set AZURE_ENDPOINT and AZURE_KEY."
+        )
     client = DocumentAnalysisClient(
         endpoint=AZURE_ENDPOINT,
         credential=AzureKeyCredential(AZURE_KEY),


### PR DESCRIPTION
## Summary
- Load the structure extraction pipeline even when Azure credentials are missing by removing the environment gate in `app.py` and handling imports gracefully.
- Make `pipeline/ocr_to_text` resilient to absent Azure dependencies or credentials, raising clear runtime errors only when PDF OCR is requested.
- Surface errors during structure extraction rather than crashing, improving the user experience when required services are unavailable.

## Testing
- `pip install tiktoken` *(fails: Could not find a version that satisfies the requirement tiktoken)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688e723876ec8324a42b172b155105d3