### PR TITLE
Fix sorting when article numbers are non-numeric

### DIFF
--- a/pipeline/hierarchy_builder.py
+++ b/pipeline/hierarchy_builder.py
@@ -102,11 +102,11 @@ def merge_duplicates(children: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
 
 
 def sort_children(children: List[Dict[str, Any]]) -> None:
-    def parse_num(n: Any) -> Any:
+    def parse_num(n: Any) -> tuple[int, Any]:
         try:
-            return int(str(n))
+            return (0, int(str(n)))
         except Exception:
-            return str(n)
+            return (1, str(n))
 
     # Determine the different node types present amongst the children.  When a
     # mixture of structural elements exists (for example ``فرع`` nodes alongside


### PR DESCRIPTION
## Summary
- avoid TypeError when sorting article nodes with mixed numeric and text numbers

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_688fb8b2fe4883248f2d0d9d438fe11e