### PR TITLE
Skip footnote lines in OCR text cleaning

### DIFF
--- a/pipeline/gpt_helpers.py
+++ b/pipeline/gpt_helpers.py
@@ -171,7 +171,15 @@ def clean_ocr_lines(text: str) -> str:
         s = line.strip()
         if s in HEADER_LINES:
             continue
+        # Remove standalone page numbers like ``- 12 -`` or ``12``
         if re.match(r"^-?\s*\d+\s*-?$", s):
+            continue
+        # Drop lines that begin with a numeric footnote marker such as
+        # ``8 - تم تغيير ...``.  These annotations are not part of the
+        # legislative text and can confuse downstream parsing which may glue
+        # the footnote digit to the article number (e.g. producing ``814``
+        # instead of ``14``).
+        if re.match(r"^\d+\s*-\s+", s):
             continue
         cleaned.append(line)
     return "\n".join(cleaned)


### PR DESCRIPTION
## Summary
- Ignore lines starting with numeric footnote markers during OCR cleanup to avoid misnumbered articles

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688fdcf837e88324a5b124a35258580e