### PR TITLE
Handle empty splits in pass2 chunking

### DIFF
--- a/gpt.py
+++ b/gpt.py
@@ -306,15 +306,24 @@ def split_for_pass2(arabic_text: str) -> list[str]:
 
     while i < total:
         window = prev_tail + tokens[i : min(i + chunk_limit, total)]
+        if not window:
+            break
         combined_text = enc.decode(window)
 
         subchunks = smart_token_split(combined_text, chunk_limit, GPT_MODEL)
-        this_chunk = subchunks[0]
-
-        chunk_tokens = enc.encode(this_chunk)
-        if prev_tail:
-            chunk_tokens = chunk_tokens[len(prev_tail):]
+        if subchunks:
+            this_chunk = subchunks[0]
+            chunk_tokens = enc.encode(this_chunk)
+            if prev_tail:
+                chunk_tokens = chunk_tokens[len(prev_tail):]
+                this_chunk = enc.decode(chunk_tokens)
+        else:
+            # Fallback to using the raw window if smart split produced nothing
+            chunk_tokens = window[len(prev_tail):] if prev_tail else window
             this_chunk = enc.decode(chunk_tokens)
+
+        if not chunk_tokens:
+            break
 
         chunks.append(this_chunk)
 

--- a/pipeline/gpt_helpers.py
+++ b/pipeline/gpt_helpers.py
@@ -269,13 +269,22 @@ def split_for_pass2(arabic_text: str) -> list[str]:
     total = len(tokens)
     while i < total:
         window = prev_tail + tokens[i : min(i + chunk_limit, total)]
+        if not window:
+            break
         combined_text = enc.decode(window)
         subchunks = smart_token_split(combined_text, chunk_limit, GPT_MODEL)
-        this_chunk = subchunks[0]
-        chunk_tokens = enc.encode(this_chunk)
-        if prev_tail:
-            chunk_tokens = chunk_tokens[len(prev_tail):]
+        if subchunks:
+            this_chunk = subchunks[0]
+            chunk_tokens = enc.encode(this_chunk)
+            if prev_tail:
+                chunk_tokens = chunk_tokens[len(prev_tail):]
+                this_chunk = enc.decode(chunk_tokens)
+        else:
+            # Fallback to using the raw window if smart split produced nothing
+            chunk_tokens = window[len(prev_tail):] if prev_tail else window
             this_chunk = enc.decode(chunk_tokens)
+        if not chunk_tokens:
+            break
         chunks.append(this_chunk)
         prev_tail = chunk_tokens[-overlap:] if overlap else []
         i += len(chunk_tokens)


### PR DESCRIPTION
## Summary
- avoid IndexError when smart token split returns empty chunk during pass 2
- apply chunking safeguards in top-level `gpt.py` helper

## Testing
- `pip install tiktoken` *(failed: Tunnel connection failed, 403 Forbidden)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689006ec97388324871afd1faa5a5969