### PR TITLE
Fix article dedup recursion

### DIFF
--- a/pipeline/hierarchy_builder.py
+++ b/pipeline/hierarchy_builder.py
@@ -214,7 +214,9 @@ def remove_duplicate_articles(children: List[Dict[str, Any]],
             else:
                 seen[num] = i
         if node.get("children"):
-            remove_duplicate_articles(node["children"], seen)
+            # Use a fresh ``seen`` map for each recursion level so that article
+            # numbers are considered unique within their local scope only.
+            remove_duplicate_articles(node["children"])
         i += 1
 
 

--- a/tests/test_remove_duplicate_articles.py
+++ b/tests/test_remove_duplicate_articles.py
@@ -1,0 +1,39 @@
+import pytest
+
+from pipeline.hierarchy_builder import remove_duplicate_articles
+
+
+def test_remove_duplicate_articles_nested_duplicates():
+    structure = [
+        {
+            "type": "قسم",
+            "number": "1",
+            "children": [
+                {"type": "مادة", "number": "1", "text": "short"},
+                {"type": "مادة", "number": "1", "text": "a much longer text"},
+                {"type": "مادة", "number": "2", "text": "unique"},
+            ],
+        },
+        {
+            "type": "قسم",
+            "number": "2",
+            "children": [
+                {"type": "مادة", "number": "1", "text": "section2 article1"}
+            ],
+        },
+    ]
+
+    remove_duplicate_articles(structure)
+
+    first_section = structure[0]["children"]
+    # Article 1 duplicate removed, longer text kept
+    assert len(first_section) == 2
+    assert first_section[0]["number"] == "1"
+    assert first_section[0]["text"] == "a much longer text"
+    assert first_section[1]["number"] == "2"
+
+    second_section = structure[1]["children"]
+    # Article numbering in second section unaffected by first
+    assert len(second_section) == 1
+    assert second_section[0]["number"] == "1"
+    assert second_section[0]["text"] == "section2 article1"


### PR DESCRIPTION
## Summary
- ensure article deduplication uses a fresh `seen` map for each recursion level
- add test covering nested duplicate article numbers

## Testing
- `python -m pytest tests/test_remove_duplicate_articles.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6890166bd780832496b9a1603e62cb53