### PR TITLE
Preserve article order during deduplication

### DIFF
--- a/tests/test_remove_duplicate_articles.py
+++ b/tests/test_remove_duplicate_articles.py
@@ -7,22 +7,33 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")
 from pipeline.hierarchy_builder import remove_duplicate_articles
 
 
-def test_remove_duplicate_articles_nested_duplicates():
+def test_prefers_more_informative_version_and_preserves_position():
+    first = {"type": "مادة", "number": "1", "text": "old"}
+    second = {"type": "مادة", "number": "1", "text": "new and improved"}
+    items = [first, second, {"type": "مادة", "number": "2", "text": "next"}]
+
+    remove_duplicate_articles(items)
+
+    assert [n["number"] for n in items] == ["1", "2"]
+    assert items[0] is first
+    assert items[0]["text"] == "new and improved"
+
+
+def test_duplicates_removed_across_sections():
     structure = [
         {
             "type": "قسم",
             "number": "1",
             "children": [
-                {"type": "مادة", "number": "1", "text": "short"},
-                {"type": "مادة", "number": "1", "text": "a much longer text"},
-                {"type": "مادة", "number": "2", "text": "unique"},
+                {"type": "مادة", "number": "1", "text": "section1 article1"},
+                {"type": "مادة", "number": "2", "text": "section1 article2"},
             ],
         },
         {
             "type": "قسم",
             "number": "2",
             "children": [
-                {"type": "مادة", "number": "1", "text": "section2 article1"}
+                {"type": "مادة", "number": "1", "text": "dup"}
             ],
         },
     ]
@@ -30,14 +41,21 @@ def test_remove_duplicate_articles_nested_duplicates():
     remove_duplicate_articles(structure)
 
     first_section = structure[0]["children"]
-    # Article 1 duplicate removed, longer text kept
-    assert len(first_section) == 2
-    assert first_section[0]["number"] == "1"
-    assert first_section[0]["text"] == "a much longer text"
-    assert first_section[1]["number"] == "2"
+    assert [n["number"] for n in first_section] == ["1", "2"]
 
     second_section = structure[1]["children"]
-    # Article numbering in second section unaffected by first
-    assert len(second_section) == 1
-    assert second_section[0]["number"] == "1"
-    assert second_section[0]["text"] == "section2 article1"
+    assert second_section == []
+
+
+def test_out_of_order_earlier_duplicate_removed():
+    items = [
+        {"type": "مادة", "number": "50", "text": "fifty"},
+        {"type": "مادة", "number": "65", "text": "stray"},
+        {"type": "مادة", "number": "51", "text": "fifty one"},
+        {"type": "مادة", "number": "65", "text": "proper sixty five"},
+    ]
+
+    remove_duplicate_articles(items)
+
+    assert [n["number"] for n in items] == ["50", "51", "65"]
+    assert items[-1]["text"] == "proper sixty five"


### PR DESCRIPTION
## Summary
- ensure article deduplication keeps sequential ordering across the entire document
- add tests covering object identity, cross-section duplicates, and removal of out-of-order articles

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68951c8b91c4832487eb58d6b3125abf