### PR TITLE
Fix branch nesting in hierarchy builder

### DIFF
--- a/pipeline/hierarchy_builder.py
+++ b/pipeline/hierarchy_builder.py
@@ -15,7 +15,14 @@ TYPE_MAP = {
 
 # Structural types we allow to keep in the final hierarchy.  Anything outside
 # this list is treated as noise and pruned during the cleanup phase.
-ALLOWED_TYPES = {"قسم", "باب", "فصل", "جزء", "فرع", "مادة"}
+STRUCTURE_TYPES = ["قسم", "باب", "جزء", "فصل", "فرع"]
+ALLOWED_TYPES = set(STRUCTURE_TYPES + ["مادة"])
+
+# Rank order for the different structural levels.  Lower numbers represent
+# higher-level containers.  Articles ("مادة") are assigned the lowest priority
+# so they sit at the leaf level and are popped from the stack when a new
+# structural element is encountered.
+LEVEL_RANK = {t: i for i, t in enumerate(STRUCTURE_TYPES + ["مادة"])}
 
 
 def canonical_type(t: str) -> str:
@@ -28,6 +35,14 @@ def canonical_type(t: str) -> str:
 
 
 def postprocess_structure(flat_structure: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """Reconstruct a hierarchical tree from the flat model output.
+
+    The language model emits a simple list of headings and articles.  This
+    function rebuilds the nested structure by using a rank for each structural
+    level.  Unknown types are appended at the root and ignored during later
+    pruning.
+    """
+
     stack: List[Dict[str, Any]] = []
     root: List[Dict[str, Any]] = []
 
@@ -36,30 +51,20 @@ def postprocess_structure(flat_structure: List[Dict[str, Any]]) -> List[Dict[str
         entry["type"] = level
         entry.setdefault("children", [])
 
-        if level == "قسم":
-            stack = [entry]
+        rank = LEVEL_RANK.get(level)
+        if rank is None:
             root.append(entry)
-        elif level == "باب":
-            while stack and stack[-1].get("type") != "قسم":
-                stack.pop()
-            if stack:
-                stack[-1].setdefault("children", []).append(entry)
-            stack.append(entry)
-        elif level == "فصل":
-            while stack and stack[-1].get("type") not in ["باب", "قسم"]:
-                stack.pop()
-            if stack:
-                stack[-1].setdefault("children", []).append(entry)
-            stack.append(entry)
-        elif level in ["مادة", "المادة"]:
-            while stack and stack[-1].get("type") not in ["فصل", "باب", "قسم"]:
-                stack.pop()
-            if stack:
-                stack[-1].setdefault("children", []).append(entry)
-            else:
-                root.append(entry)
+            continue
+
+        while stack and LEVEL_RANK.get(stack[-1].get("type", ""), -1) >= rank:
+            stack.pop()
+
+        if stack:
+            stack[-1].setdefault("children", []).append(entry)
         else:
             root.append(entry)
+
+        stack.append(entry)
 
     return root
 
@@ -271,24 +276,22 @@ def attach_stray_articles(children: List[Dict[str, Any]]) -> None:
 
     i = 0
     last_struct: Dict[str, Any] | None = None
+    structural = set(STRUCTURE_TYPES)
+
     while i < len(children):
         node = children[i]
         node_type = canonical_type(node.get("type", ""))
 
-        if node_type in {"قسم", "باب", "فصل"}:
-            # Occasionally a ``فصل`` heading is emitted at the same hierarchical
-            # level as its preceding ``باب``.  When this happens we should nest
-            # the chapter under the most recent ``باب`` instead of leaving it as
-            # a sibling.  This mirrors the logic used for stray article nodes
-            # below.
+        if node_type in structural:
             if (
-                node_type == "فصل"
-                and last_struct is not None
-                and canonical_type(last_struct.get("type", "")) == "باب"
+                last_struct is not None
+                and LEVEL_RANK.get(node_type, 0)
+                > LEVEL_RANK.get(canonical_type(last_struct.get("type", "")), 0)
             ):
                 last_struct.setdefault("children", []).append(node)
                 children.pop(i)
                 attach_stray_articles(node.get("children", []))
+                last_struct = node
                 continue
 
             attach_stray_articles(node.get("children", []))
@@ -298,10 +301,8 @@ def attach_stray_articles(children: List[Dict[str, Any]]) -> None:
 
         if node_type == "مادة" and last_struct is not None:
             target = last_struct
-            if canonical_type(target.get("type", "")) in {"قسم", "باب"}:
-                sub = target.get("children", [])
-                if sub and canonical_type(sub[-1].get("type", "")) == "فصل":
-                    target = sub[-1]
+            while target.get("children") and canonical_type(target.get("children")[-1].get("type", "")) in structural:
+                target = target.get("children")[-1]
             target.setdefault("children", []).append(node)
             children.pop(i)
             continue

--- a/tests/test_branch_nesting.py
+++ b/tests/test_branch_nesting.py
@@ -1,0 +1,32 @@
+import os, sys
+import copy
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from pipeline.post_process import post_process_data
+
+
+def test_branch_nesting_order():
+    data = {
+        "structure": [
+            {"type": "القسم", "number": "1"},
+            {"type": "الباب", "number": "1"},
+            {"type": "الفرع", "number": "1"},
+            {"type": "المادة", "number": "1", "text": "a"},
+            {"type": "المادة", "number": "2", "text": "b"},
+            {"type": "الفرع", "number": "2"},
+            {"type": "المادة", "number": "3", "text": "c"},
+            {"type": "الفرع", "number": "3"},
+            {"type": "المادة", "number": "4", "text": "d"},
+        ]
+    }
+
+    result = post_process_data(copy.deepcopy(data))
+    section = result["structure"][0]
+    chapter = section["children"][0]
+    branches = chapter["children"]
+
+    assert [b["number"] for b in branches] == ["1", "2", "3"]
+    assert [a["number"] for a in branches[0]["children"]] == ["1", "2"]
+    assert [a["number"] for a in branches[1]["children"]] == ["3"]
+    assert [a["number"] for a in branches[2]["children"]] == ["4"]


### PR DESCRIPTION
## Summary
- handle "فرع" levels when reconstructing hierarchy
- ensure stray articles attach to latest structural parent
- test branch nesting ordering

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68952845d58883249b236b54484c716d