### PR TITLE
Enable NER on JSON documents

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,9 +64,11 @@ Running them with `-m` ensures relative imports resolve correctly when executed 
 
 # Named‑entity extraction
 ```bash
-python ner.py --input path/to/text.txt --output_dir ner_out
+python ner.py --input path/to/file.json --output_dir ner_out
 ```
-This creates entities.csv and relations.csv inside the output directory. Using a PDF file as input triggers automatic OCR.
+This creates entities.csv and relations.csv inside the output directory. The
+input can be a PDF, plain text, or a structured JSON file. Using a PDF file as
+input triggers automatic OCR.
 
 Pass `--annotate_text` to also save a copy of the input text where entity spans
 are wrapped in `[[ENT …]]` markers. The Streamlit and Flask interfaces accept

--- a/tests/test_json_to_text.py
+++ b/tests/test_json_to_text.py
@@ -1,0 +1,18 @@
+from ner import json_to_text
+
+
+def test_json_to_text_extracts_all_strings():
+    sample = {
+        "preamble": "intro",
+        "chapters": [
+            {"articles": [{"text": "art1"}, {"text": "art2"}]},
+        ],
+        "nested": {"inner": "deep"},
+        "number": 5,
+    }
+    text = json_to_text(sample)
+    assert "intro" in text
+    assert "art1" in text
+    assert "art2" in text
+    assert "deep" in text
+    assert "5" not in text


### PR DESCRIPTION
## Summary
- Extend `ner.py` to read JSON inputs and recursively gather text, allowing NER on article and preamble content.
- Update CLI and documentation to mention JSON support.
- Add unit test ensuring JSON structures are flattened into text correctly.

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68955854561c8324bea2c966525b528b