### PR TITLE
Enable automatic NER and HTML highlights in pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,11 +62,20 @@ python -m pipeline.run_pipeline --input path/to/document.pdf --output_dir output
 ```
 Running them with `-m` ensures relative imports resolve correctly when executed from the repository root.
 
+Running `pipeline.run_pipeline` now also performs named‑entity recognition on
+the extracted text and writes two extra files alongside the structured JSON:
+
+* `<document>_ner.json` – raw entities and relations
+* `<document>_ner.html` – HTML with clickable entities highlighting references
+  and relationships
+
 # Named‑entity extraction
 ```bash
-python ner.py --input path/to/text.txt --output_dir ner_out
+python ner.py --input path/to/file.json --output_dir ner_out
 ```
-This creates entities.csv and relations.csv inside the output directory. Using a PDF file as input triggers automatic OCR.
+This creates entities.csv and relations.csv inside the output directory. The
+input can be a PDF, plain text, or a structured JSON file. Using a PDF file as
+input triggers automatic OCR.
 
 Pass `--annotate_text` to also save a copy of the input text where entity spans
 are wrapped in `[[ENT …]]` markers. The Streamlit and Flask interfaces accept

--- a/pipeline/run_pipeline.py
+++ b/pipeline/run_pipeline.py
@@ -6,6 +6,13 @@ from .ocr_to_text import convert_to_text
 from .extract_chunks import run_passes
 from .post_process import post_process_data
 
+try:
+    from ..ner import extract_entities, postprocess_result  # type: ignore
+    from ..highlight import render_ner_html  # type: ignore
+except Exception:  # pragma: no cover
+    from ner import extract_entities, postprocess_result  # type: ignore
+    from highlight import render_ner_html  # type: ignore
+
 
 def main() -> None:
     parser = argparse.ArgumentParser(
@@ -33,6 +40,23 @@ def main() -> None:
 
     print(f"[+] Saved raw structure to: {raw_json}")
     print(f"[+] Saved final structure to: {final_json}")
+
+    with open(txt_path, "r", encoding="utf-8") as f:
+        raw_text = f.read()
+
+    ner_result = extract_entities(raw_text, args.model)
+    postprocess_result(raw_text, ner_result)
+    ner_json = os.path.join(args.output_dir, f"{base}_ner.json")
+    with open(ner_json, "w", encoding="utf-8") as f:
+        json.dump(ner_result, f, ensure_ascii=False, indent=2)
+
+    html = render_ner_html(raw_text, ner_result)
+    html_path = os.path.join(args.output_dir, f"{base}_ner.html")
+    with open(html_path, "w", encoding="utf-8") as f:
+        f.write(html)
+
+    print(f"[+] Saved NER result to: {ner_json}")
+    print(f"[+] Saved NER HTML to: {html_path}")
 
 
 if __name__ == "__main__":

--- a/tests/test_json_to_text.py
+++ b/tests/test_json_to_text.py
@@ -1,0 +1,18 @@
+from ner import json_to_text
+
+
+def test_json_to_text_extracts_all_strings():
+    sample = {
+        "preamble": "intro",
+        "chapters": [
+            {"articles": [{"text": "art1"}, {"text": "art2"}]},
+        ],
+        "nested": {"inner": "deep"},
+        "number": 5,
+    }
+    text = json_to_text(sample)
+    assert "intro" in text
+    assert "art1" in text
+    assert "art2" in text
+    assert "deep" in text
+    assert "5" not in text

--- a/tests/test_render_ner_html.py
+++ b/tests/test_render_ner_html.py
@@ -1,0 +1,17 @@
+from highlight import render_ner_html
+
+
+def test_render_ner_html_relations():
+    text = 'القانون 1 يشير إلى الفصل 2'
+    result = {
+        'entities': [
+            {'id': 1, 'type': 'LAW', 'text': 'القانون 1', 'start_char': 0, 'end_char': 9},
+            {'id': 2, 'type': 'ARTICLE', 'text': 'الفصل 2', 'start_char': 19, 'end_char': 26},
+        ],
+        'relations': [
+            {'source_id': 1, 'target_id': 2, 'type': 'refers_to'}
+        ],
+    }
+    html = render_ner_html(text, result)
+    assert 'entity-mark' in html
+    assert 'data-rel="القانون 1 يشير إلى الفصل 2"' in html


### PR DESCRIPTION
## Summary
- Run NER within `pipeline.run_pipeline` and export entity JSON and an interactive HTML page
- Expose `render_ner_html` helper to build clickable entity markup with relation tooltips
- Document that the pipeline now emits highlighted NER output

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68955854561c8324bea2c966525b528b