### PR TITLE
Run NER after structure extraction

### DIFF
--- a/templates/structure.html
+++ b/templates/structure.html
@@ -78,6 +78,12 @@
         }
         render(document.getElementById('json-tree'), data);
         </script>
+        {% if ner_html %}
+        <section class="card">
+            <h2>Named Entities</h2>
+            {{ ner_html | safe }}
+        </section>
+        {% endif %}
     {% endif %}
 </main>
 </body>


### PR DESCRIPTION
### Summary
- invoke NER during structure pipeline and store JSON/HTML outputs
- display extracted entities with clickable highlights in structure view

### Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68956012aac883249b6a978653084eec