### PR TITLE
Show NER entities with legislation display

### DIFF
--- a/templates/legislation.html
+++ b/templates/legislation.html
@@ -47,6 +47,16 @@
     </section>
     <script>
     const data = {{ data | tojson }};
+    const entities = {{ ner_entities | default([]) | tojson | safe }};
+    function escapeRegExp(string){return string.replace(/[-/\\^$*+?.()|[\]{}]/g,'\\$&');}
+    function highlightEntities(text){
+        let html=text;
+        entities.forEach(ent=>{
+            const pattern=new RegExp(escapeRegExp(ent.text),'g');
+            html=html.replace(pattern,`<span class="ner-span"><mark class="entity-mark" title="${ent.type}">${ent.text}</mark></span>`);
+        });
+        return html;
+    }
     function render(container, obj) {
         if (Array.isArray(obj)) {
             const ul = document.createElement('ul');
@@ -75,7 +85,7 @@
                     keySpan.textContent = key + ': ';
                     const valSpan = document.createElement('span');
                     valSpan.className = 'json-value';
-                    valSpan.textContent = value;
+                    valSpan.innerHTML = highlightEntities(String(value));
                     li.appendChild(keySpan);
                     li.appendChild(valSpan);
                 }
@@ -85,7 +95,7 @@
         } else {
             const valSpan = document.createElement('span');
             valSpan.className = 'json-value';
-            valSpan.textContent = obj;
+            valSpan.innerHTML = highlightEntities(String(obj));
             container.appendChild(valSpan);
         }
     }

--- a/templates/structure.html
+++ b/templates/structure.html
@@ -46,6 +46,16 @@
         </section>
         <script>
         const data = {{ result | tojson }};
+        const entities = {{ ner_entities | default([]) | tojson | safe }};
+        function escapeRegExp(string){return string.replace(/[-/\\^$*+?.()|[\]{}]/g,'\\$&');}
+        function highlightEntities(text){
+            let html=text;
+            entities.forEach(ent=>{
+                const pattern=new RegExp(escapeRegExp(ent.text),'g');
+                html=html.replace(pattern,`<span class="ner-span"><mark class="entity-mark" title="${ent.type}">${ent.text}</mark></span>`);
+            });
+            return html;
+        }
         function render(container, obj) {
             if (Array.isArray(obj)) {
                 const ul = document.createElement('ul');
@@ -67,23 +77,17 @@
                         render(details, value);
                         li.appendChild(details);
                     } else {
-                        li.textContent = key + ': ' + value;
+                        li.innerHTML = key + ': ' + highlightEntities(String(value));
                     }
                     ul.appendChild(li);
                 }
                 container.appendChild(ul);
             } else {
-                container.textContent = obj;
+                container.innerHTML = highlightEntities(String(obj));
             }
         }
         render(document.getElementById('json-tree'), data);
         </script>
-        {% if ner_html %}
-        <section class="card">
-            <h2>Named Entities</h2>
-            {{ ner_html | safe }}
-        </section>
-        {% endif %}
     {% endif %}
 </main>
 </body>


### PR DESCRIPTION
## Summary
- Highlight named entities directly within structure and legislation JSON views
- Load entity data from saved `ner_output` JSON files rather than rendering raw text blocks

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6895666892c88324b7beff85bc711014