### PR TITLE
Show NER data in legislation tree

### DIFF
--- a/templates/legislation.html
+++ b/templates/legislation.html
@@ -41,12 +41,6 @@
     });
     </script>
     {% if data %}
-    {% if ner_html %}
-    <section class="card">
-        <h2>Named Entities</h2>
-        {{ ner_html | safe }}
-    </section>
-    {% endif %}
     <section class="card">
         <h2>{{ selected }}</h2>
         <div id="json-tree" class="json-tree"></div>
@@ -56,9 +50,23 @@
     function render(container, obj) {
         if (Array.isArray(obj)) {
             const ul = document.createElement('ul');
-            obj.forEach(item => {
+            obj.forEach((item, idx) => {
                 const li = document.createElement('li');
-                render(li, item);
+                if (typeof item === 'object' && item !== null) {
+                    const details = document.createElement('details');
+                    const summary = document.createElement('summary');
+                    summary.classList.add('json-key');
+                    let label = item.text || item.title || item.number || item.id || idx;
+                    if (typeof label === 'string' && label.length > 40) {
+                        label = label.slice(0, 40) + '...';
+                    }
+                    summary.textContent = label;
+                    details.appendChild(summary);
+                    render(details, item);
+                    li.appendChild(details);
+                } else {
+                    render(li, item);
+                }
                 ul.appendChild(li);
             });
             container.appendChild(ul);

--- a/tests/test_view_legislation_entities.py
+++ b/tests/test_view_legislation_entities.py
@@ -1,0 +1,34 @@
+import json
+import pytest
+
+flask = pytest.importorskip('flask')
+from app import app
+
+
+def test_view_legislation_includes_entities(tmp_path, monkeypatch):
+    out_dir = tmp_path / 'output'
+    out_dir.mkdir()
+
+    structure_path = out_dir / 'test.json'
+    with open(structure_path, 'w', encoding='utf-8') as f:
+        json.dump({}, f)
+
+    ner_data = {
+        'entities': [
+            {'id': 1, 'text': 'القانون 1', 'type': 'LAW'},
+            {'id': 2, 'text': 'الفصل 2', 'type': 'ARTICLE'},
+        ],
+        'relations': [
+            {'source_id': 1, 'target_id': 2, 'type': 'refers_to'},
+        ],
+    }
+    ner_path = out_dir / 'test_ner.json'
+    with open(ner_path, 'w', encoding='utf-8') as f:
+        json.dump(ner_data, f)
+
+    monkeypatch.chdir(tmp_path)
+    client = app.test_client()
+    resp = client.get('/legislation?file=test.json')
+    assert resp.status_code == 200
+    body = resp.get_data(as_text=True)
+    assert 'القانون 1 يشير إلى الفصل 2' in body


### PR DESCRIPTION
## Summary
- Load NER JSON from either `ner_output` or alongside legislation files so entity info is embedded in the legislation tree
- Update regression test to verify entities appear when NER data is saved beside the legislation JSON

## Testing
- `pytest` *(fails to install Flask: Could not connect to proxy; 7 tests passed, 1 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_689571fd1ee8832492b5ff48655063d1