### PR TITLE
Highlight entities in structured JSON output

### DIFF
--- a/pipeline/run_pipeline.py
+++ b/pipeline/run_pipeline.py
@@ -8,10 +8,10 @@ from .post_process import post_process_data
 
 try:
     from ..ner import extract_entities, postprocess_result  # type: ignore
-    from ..highlight import render_ner_html  # type: ignore
+    from ..highlight import render_ner_html, highlight_structure  # type: ignore
 except Exception:  # pragma: no cover
     from ner import extract_entities, postprocess_result  # type: ignore
-    from highlight import render_ner_html  # type: ignore
+    from highlight import render_ner_html, highlight_structure  # type: ignore
 
 
 def main() -> None:
@@ -57,6 +57,13 @@ def main() -> None:
 
     print(f"[+] Saved NER result to: {ner_json}")
     print(f"[+] Saved NER HTML to: {html_path}")
+
+    # Save a copy of the structured JSON with entity mentions highlighted
+    highlight_structure(final_data.get("structure", []), ner_result.get("entities", []))
+    highlight_json = os.path.join(args.output_dir, f"{base}_highlight.json")
+    with open(highlight_json, "w", encoding="utf-8") as f:
+        json.dump(final_data, f, ensure_ascii=False, indent=2)
+    print(f"[+] Saved highlighted structure to: {highlight_json}")
 
 
 if __name__ == "__main__":

--- a/tests/test_highlight_structure.py
+++ b/tests/test_highlight_structure.py
@@ -1,0 +1,8 @@
+from highlight import highlight_structure
+
+
+def test_highlight_structure_inserts_mark():
+    structure = [{"type": "مادة", "number": "1", "text": "المحكمة الابتدائية بالرباط تحكم"}]
+    entities = [{"text": "المحكمة الابتدائية بالرباط"}]
+    highlight_structure(structure, entities)
+    assert "<mark>المحكمة الابتدائية بالرباط</mark>" in structure[0]["text"]


### PR DESCRIPTION
## Summary
- Add utility to wrap entity mentions in `<mark>` tags and recursively highlight structured JSON nodes.
- Integrate highlighting into pipeline run to emit `<document>_highlight.json` with entities marked.
- Cover new behavior with unit test.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68957dc39ed88324b50f06be375a0ffa