### PR TITLE
Add standalone structured NER script

### DIFF
--- a/pipeline/run_pipeline.py
+++ b/pipeline/run_pipeline.py
@@ -6,13 +6,6 @@ from .ocr_to_text import convert_to_text
 from .extract_chunks import run_passes
 from .post_process import post_process_data
 
-try:
-    from ..ner import extract_entities, postprocess_result  # type: ignore
-    from ..highlight import render_ner_html, highlight_structure  # type: ignore
-except Exception:  # pragma: no cover
-    from ner import extract_entities, postprocess_result  # type: ignore
-    from highlight import render_ner_html, highlight_structure  # type: ignore
-
 
 def main() -> None:
     parser = argparse.ArgumentParser(
@@ -40,30 +33,6 @@ def main() -> None:
 
     print(f"[+] Saved raw structure to: {raw_json}")
     print(f"[+] Saved final structure to: {final_json}")
-
-    with open(txt_path, "r", encoding="utf-8") as f:
-        raw_text = f.read()
-
-    ner_result = extract_entities(raw_text, args.model)
-    postprocess_result(raw_text, ner_result)
-    ner_json = os.path.join(args.output_dir, f"{base}_ner.json")
-    with open(ner_json, "w", encoding="utf-8") as f:
-        json.dump(ner_result, f, ensure_ascii=False, indent=2)
-
-    html = render_ner_html(raw_text, ner_result)
-    html_path = os.path.join(args.output_dir, f"{base}_ner.html")
-    with open(html_path, "w", encoding="utf-8") as f:
-        f.write(html)
-
-    print(f"[+] Saved NER result to: {ner_json}")
-    print(f"[+] Saved NER HTML to: {html_path}")
-
-    # Save a copy of the structured JSON with entity mentions highlighted
-    highlight_structure(final_data.get("structure", []), ner_result.get("entities", []))
-    highlight_json = os.path.join(args.output_dir, f"{base}_highlight.json")
-    with open(highlight_json, "w", encoding="utf-8") as f:
-        json.dump(final_data, f, ensure_ascii=False, indent=2)
-    print(f"[+] Saved highlighted structure to: {highlight_json}")
 
 
 if __name__ == "__main__":

--- a/structured_ner.py
+++ b/structured_ner.py
@@ -1,0 +1,58 @@
+import argparse
+import json
+import re
+from typing import Any, Dict, List
+
+from ner import extract_entities, postprocess_result, json_to_text
+
+
+def _insert_brackets(text: str, entities: List[Dict[str, Any]]) -> str:
+    """Wrap entity mentions in *text* with ``[TYPE:TEXT]`` markers."""
+    patterns = [(e.get("text", ""), e.get("type", "")) for e in entities if e.get("text")]
+    if not patterns:
+        return text
+    patterns.sort(key=lambda x: len(x[0]), reverse=True)
+    for ent_text, ent_type in patterns:
+        pattern = re.escape(ent_text)
+        replacement = f"[{ent_type}:{ent_text}]" if ent_type else f"[{ent_text}]"
+        text = re.sub(pattern, replacement, text)
+    return text
+
+
+def annotate_structure(structure: List[Dict[str, Any]], entities: List[Dict[str, Any]]) -> None:
+    """Recursively insert entity markers into ``text`` and ``title`` fields."""
+    for node in structure:
+        txt = node.get("text")
+        if isinstance(txt, str):
+            node["text"] = _insert_brackets(txt, entities)
+        title = node.get("title")
+        if isinstance(title, str):
+            node["title"] = _insert_brackets(title, entities)
+        children = node.get("children")
+        if isinstance(children, list):
+            annotate_structure(children, entities)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Run NER over structured JSON and embed entity mentions in brackets.",
+    )
+    parser.add_argument("--input", required=True, help="Path to input JSON file")
+    parser.add_argument("--output", required=True, help="Path to output JSON file")
+    parser.add_argument("--model", default="gpt-4o", help="OpenAI model to use")
+    args = parser.parse_args()
+
+    with open(args.input, "r", encoding="utf-8") as f:
+        data = json.load(f)
+
+    text = json_to_text(data)
+    ner_result = extract_entities(text, args.model)
+    postprocess_result(text, ner_result)
+    annotate_structure(data.get("structure", []), ner_result.get("entities", []))
+
+    with open(args.output, "w", encoding="utf-8") as f:
+        json.dump(data, f, ensure_ascii=False, indent=2)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_structured_ner.py
+++ b/tests/test_structured_ner.py
@@ -1,0 +1,19 @@
+from structured_ner import _insert_brackets, annotate_structure
+
+
+def test_insert_brackets_simple():
+    text = "القانون 1 يشير إلى الفصل 2"
+    entities = [
+        {"text": "القانون 1", "type": "LAW"},
+        {"text": "الفصل 2", "type": "ARTICLE"},
+    ]
+    marked = _insert_brackets(text, entities)
+    assert "[LAW:القانون 1]" in marked
+    assert "[ARTICLE:الفصل 2]" in marked
+
+
+def test_annotate_structure_in_place():
+    structure = [{"text": "القانون 1"}]
+    entities = [{"text": "القانون 1", "type": "LAW"}]
+    annotate_structure(structure, entities)
+    assert structure[0]["text"] == "[LAW:القانون 1]"


### PR DESCRIPTION
## Summary
- Remove NER step from main pipeline
- Add `structured_ner.py` for standalone NER that embeds entity mentions in bracketed form
- Add tests for bracket insertion and structured annotation

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6896939395108324b18e8bdcfd55bcf7