### PR TITLE
Improve structured NER annotation coverage and deduplication

### DIFF
--- a/tests/test_structured_ner.py
+++ b/tests/test_structured_ner.py
@@ -1,4 +1,4 @@
-from structured_ner import _insert_brackets, annotate_structure
+from structured_ner import _insert_brackets, annotate_structure, annotate_json
 
 
 def test_insert_brackets_simple():
@@ -17,3 +17,21 @@ def test_annotate_structure_in_place():
     entities = [{"text": "القانون 1", "type": "LAW"}]
     annotate_structure(structure, entities)
     assert structure[0]["text"] == "[LAW:القانون 1]"
+
+
+def test_insert_brackets_deduplicates():
+    text = "القانون 1 القانون 1"
+    entities = [
+        {"text": "القانون 1", "type": "LAW"},
+        {"text": "القانون 1", "type": "LAW"},
+    ]
+    marked = _insert_brackets(text, entities)
+    assert marked.count("[LAW:القانون 1]") == 2
+    assert "[LAW:[LAW:القانون 1]" not in marked
+
+
+def test_annotate_json_metadata():
+    data = {"metadata": {"official_title": "القانون 1"}, "structure": []}
+    entities = [{"text": "القانون 1", "type": "LAW"}]
+    annotate_json(data, entities)
+    assert data["metadata"]["official_title"] == "[LAW:القانون 1]"


### PR DESCRIPTION
## Summary
- Avoid nested entity markers by deduplicating entity patterns before replacement
- Add `annotate_json` to apply entity markers to all string fields, including metadata
- Expand test coverage for deduplication and metadata annotation

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689772bafc2c832492ed09d7ac911ea4