### PR TITLE
Include NER relations in structured output

### DIFF
--- a/structured_ner.py
+++ b/structured_ner.py
@@ -48,7 +48,11 @@ def main() -> None:
     text = json_to_text(data)
     ner_result = extract_entities(text, args.model)
     postprocess_result(text, ner_result)
-    annotate_structure(data.get("structure", []), ner_result.get("entities", []))
+    entities = ner_result.get("entities", [])
+    relations = ner_result.get("relations", [])
+    annotate_structure(data.get("structure", []), entities)
+    if relations:
+        data["relations"] = relations
 
     with open(args.output, "w", encoding="utf-8") as f:
         json.dump(data, f, ensure_ascii=False, indent=2)

--- a/tests/test_structured_ner.py
+++ b/tests/test_structured_ner.py
@@ -1,3 +1,7 @@
+import json
+import sys
+
+import structured_ner
 from structured_ner import _insert_brackets, annotate_structure
 
 
@@ -17,3 +21,41 @@ def test_annotate_structure_in_place():
     entities = [{"text": "القانون 1", "type": "LAW"}]
     annotate_structure(structure, entities)
     assert structure[0]["text"] == "[LAW:القانون 1]"
+
+
+def test_main_saves_relations(tmp_path, monkeypatch):
+    input_path = tmp_path / "in.json"
+    output_path = tmp_path / "out.json"
+    with open(input_path, "w", encoding="utf-8") as f:
+        json.dump({"structure": [{"text": "القانون 1 يشير إلى الفصل 2"}]}, f)
+
+    ner_result = {
+        "entities": [
+            {"id": 1, "type": "LAW", "text": "القانون 1", "start_char": 0, "end_char": 9},
+            {"id": 2, "type": "ARTICLE", "text": "الفصل 2", "start_char": 19, "end_char": 26},
+        ],
+        "relations": [
+            {"source_id": 1, "target_id": 2, "type": "refers_to"}
+        ],
+    }
+
+    monkeypatch.setattr(
+        structured_ner, "extract_entities", lambda text, model: ner_result
+    )
+    monkeypatch.setattr(structured_ner, "postprocess_result", lambda text, res: None)
+
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["structured_ner", "--input", str(input_path), "--output", str(output_path)],
+    )
+    structured_ner.main()
+
+    with open(output_path, "r", encoding="utf-8") as f:
+        saved = json.load(f)
+
+    assert saved["relations"] == ner_result["relations"]
+    assert saved["relations"][0]["source_id"] == 1
+    assert saved["relations"][0]["target_id"] == 2
+    assert saved["relations"][0]["type"] == "refers_to"
+    assert saved["structure"][0]["text"] == "[LAW:القانون 1] يشير إلى [ARTICLE:الفصل 2]"


### PR DESCRIPTION
## Summary
- Capture `relations` from NER results in `structured_ner` and persist them alongside the annotated structure
- Add regression test exercising CLI flow to ensure relations referencing articles are written to JSON output
- Verify relation details like source and target IDs and relation type are preserved

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6897756bd2f4832491bbbc6f7e9c5404