### PR TITLE
Improve structured NER output and entity tagging

### DIFF
--- a/tests/test_structured_ner.py
+++ b/tests/test_structured_ner.py
@@ -7,37 +7,37 @@ from structured_ner import _insert_brackets, annotate_structure, annotate_json
 def test_insert_brackets_simple():
     text = "القانون 1 يشير إلى الفصل 2"
     entities = [
-        {"text": "القانون 1", "type": "LAW"},
-        {"text": "الفصل 2", "type": "ARTICLE"},
+        {"id": "LAW_1", "text": "القانون 1", "type": "LAW"},
+        {"id": "ARTICLE_2", "text": "الفصل 2", "type": "ARTICLE"},
     ]
     marked = _insert_brackets(text, entities)
-    assert "[LAW:القانون 1]" in marked
-    assert "[ARTICLE:الفصل 2]" in marked
+    assert "<القانون 1, id:LAW_1>" in marked
+    assert "<الفصل 2, id:ARTICLE_2>" in marked
 
 
 def test_annotate_structure_in_place():
     structure = [{"text": "القانون 1"}]
-    entities = [{"text": "القانون 1", "type": "LAW"}]
+    entities = [{"id": "LAW_1", "text": "القانون 1", "type": "LAW"}]
     annotate_structure(structure, entities)
-    assert structure[0]["text"] == "[LAW:القانون 1]"
+    assert structure[0]["text"] == "<القانون 1, id:LAW_1>"
 
 
 def test_insert_brackets_deduplicates():
     text = "القانون 1 القانون 1"
     entities = [
-        {"text": "القانون 1", "type": "LAW"},
-        {"text": "القانون 1", "type": "LAW"},
+        {"id": "LAW_1", "text": "القانون 1", "type": "LAW"},
+        {"id": "LAW_1", "text": "القانون 1", "type": "LAW"},
     ]
     marked = _insert_brackets(text, entities)
-    assert marked.count("[LAW:القانون 1]") == 2
-    assert "[LAW:[LAW:القانون 1]" not in marked
+    assert marked.count("<القانون 1, id:LAW_1>") == 2
+    assert "<<" not in marked
 
 
 def test_annotate_json_metadata():
     data = {"metadata": {"official_title": "القانون 1"}, "structure": []}
-    entities = [{"text": "القانون 1", "type": "LAW"}]
+    entities = [{"id": "LAW_1", "text": "القانون 1", "type": "LAW"}]
     annotate_json(data, entities)
-    assert data["metadata"]["official_title"] == "[LAW:القانون 1]"
+    assert data["metadata"]["official_title"] == "<القانون 1, id:LAW_1>"
 
 
 def test_main_saves_relations(tmp_path, monkeypatch):
@@ -84,3 +84,49 @@ def test_main_saves_relations(tmp_path, monkeypatch):
 
     assert out["relations"] == ner_result["relations"]
     assert out["relations"][0]["target_id"] == "ARTICLE_2"
+
+
+def test_entities_output_without_positions(tmp_path, monkeypatch):
+    input_path = tmp_path / "in.json"
+    output_path = tmp_path / "out.json"
+    ent_path = tmp_path / "entities.json"
+    data = {"structure": [{"text": "المادة 1"}]}
+    with open(input_path, "w", encoding="utf-8") as f:
+        json.dump(data, f)
+
+    ner_result = {
+        "entities": [
+            {
+                "id": "ARTICLE_1",
+                "type": "ARTICLE",
+                "text": "المادة 1",
+                "start_char": 0,
+                "end_char": 7,
+            }
+        ],
+        "relations": [],
+    }
+
+    monkeypatch.setattr(structured_ner, "extract_entities", lambda text, model: ner_result)
+    monkeypatch.setattr(structured_ner, "postprocess_result", lambda text, res: None)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "structured_ner",
+            "--input",
+            str(input_path),
+            "--output",
+            str(output_path),
+            "--entities-output",
+            str(ent_path),
+        ],
+    )
+
+    structured_ner.main()
+
+    with open(ent_path, "r", encoding="utf-8") as f:
+        ents = json.load(f)["entities"]
+
+    assert "start_char" not in ents[0]
+    assert "end_char" not in ents[0]


### PR DESCRIPTION
## Summary
- Add optional `--entities-output` argument to `structured_ner.py` to save entities/relations without character offsets
- Change entity markers to `<text, id:ID>` and avoid nested replacements
- Update tests for new tag format and verify positional data removal

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6897820c8e308324b01799c2322f2bb7