### PR TITLE
Improve structured NER output and entity tagging

### DIFF
--- a/structured_ner.py
+++ b/structured_ner.py
@@ -6,24 +6,58 @@ from typing import Any, Dict, List
 from ner import extract_entities, postprocess_result, json_to_text
 
 
+def _remove_positions(obj: Any) -> None:
+    """Recursively remove ``start_char`` and ``end_char`` keys from *obj*."""
+    if isinstance(obj, dict):
+        obj.pop("start_char", None)
+        obj.pop("end_char", None)
+        for v in obj.values():
+            _remove_positions(v)
+    elif isinstance(obj, list):
+        for item in obj:
+            _remove_positions(item)
+
+
+def _replace_outside_tags(text: str, search: str, repl: str) -> str:
+    """Return *text* with all occurrences of ``search`` replaced by ``repl``
+    while skipping regions already wrapped in ``<>`` tags."""
+    result: List[str] = []
+    i = 0
+    slen = len(search)
+    while i < len(text):
+        idx = text.find(search, i)
+        if idx == -1:
+            result.append(text[i:])
+            break
+        # check if we're inside an existing tag
+        before = text[:idx]
+        if before.rfind("<") > before.rfind(">"):
+            # inside a tag – skip this occurrence
+            result.append(text[i: idx + slen])
+            i = idx + slen
+            continue
+        result.append(text[i:idx])
+        result.append(repl)
+        i = idx + slen
+    return "".join(result)
+
+
 def _insert_brackets(text: str, entities: List[Dict[str, Any]]) -> str:
-    """Wrap entity mentions in *text* with ``[TYPE:TEXT]`` markers."""
-    # Deduplicate entity texts to avoid repeated nested markers
+    """Wrap entity mentions in *text* with ``<TEXT, id:ID>`` markers."""
     seen = set()
-    patterns = []
+    patterns: List[tuple[str, str]] = []
     for e in entities:
         ent_text = e.get("text", "")
-        ent_type = e.get("type", "")
-        if ent_text and (ent_text, ent_type) not in seen:
-            patterns.append((ent_text, ent_type))
-            seen.add((ent_text, ent_type))
+        ent_id = e.get("id", "")
+        if ent_text and ent_id and (ent_text, ent_id) not in seen:
+            patterns.append((ent_text, ent_id))
+            seen.add((ent_text, ent_id))
     if not patterns:
         return text
     patterns.sort(key=lambda x: len(x[0]), reverse=True)
-    for ent_text, ent_type in patterns:
-        pattern = re.escape(ent_text)
-        replacement = f"[{ent_type}:{ent_text}]" if ent_type else f"[{ent_text}]"
-        text = re.sub(pattern, replacement, text)
+    for ent_text, ent_id in patterns:
+        replacement = f"<{ent_text}, id:{ent_id}>"
+        text = _replace_outside_tags(text, ent_text, replacement)
     return text
 
 
@@ -60,6 +94,10 @@ def main() -> None:
     )
     parser.add_argument("--input", required=True, help="Path to input JSON file")
     parser.add_argument("--output", required=True, help="Path to output JSON file")
+    parser.add_argument(
+        "--entities-output",
+        help="Optional path to save raw NER result (entities and relations)",
+    )
     parser.add_argument("--model", default="gpt-4o", help="OpenAI model to use")
     args = parser.parse_args()
 
@@ -71,12 +109,24 @@ def main() -> None:
     postprocess_result(text, ner_result)
     entities = ner_result.get("entities", [])
     relations = ner_result.get("relations", [])
+
+    # remove positional information before saving/annotating
+    _remove_positions(entities)
+    _remove_positions(relations)
+
     annotate_json(data, entities)
     if relations:
         data["relations"] = relations
 
     with open(args.output, "w", encoding="utf-8") as f:
         json.dump(data, f, ensure_ascii=False, indent=2)
+
+    if args.entities_output:
+        ner_out = {"entities": entities}
+        if relations:
+            ner_out["relations"] = relations
+        with open(args.entities_output, "w", encoding="utf-8") as f:
+            json.dump(ner_out, f, ensure_ascii=False, indent=2)
 
 
 if __name__ == "__main__":

--- a/tests/test_structured_ner.py
+++ b/tests/test_structured_ner.py
@@ -7,37 +7,37 @@ from structured_ner import _insert_brackets, annotate_structure, annotate_json
 def test_insert_brackets_simple():
     text = "القانون 1 يشير إلى الفصل 2"
     entities = [
-        {"text": "القانون 1", "type": "LAW"},
-        {"text": "الفصل 2", "type": "ARTICLE"},
+        {"id": "LAW_1", "text": "القانون 1", "type": "LAW"},
+        {"id": "ARTICLE_2", "text": "الفصل 2", "type": "ARTICLE"},
     ]
     marked = _insert_brackets(text, entities)
-    assert "[LAW:القانون 1]" in marked
-    assert "[ARTICLE:الفصل 2]" in marked
+    assert "<القانون 1, id:LAW_1>" in marked
+    assert "<الفصل 2, id:ARTICLE_2>" in marked
 
 
 def test_annotate_structure_in_place():
     structure = [{"text": "القانون 1"}]
-    entities = [{"text": "القانون 1", "type": "LAW"}]
+    entities = [{"id": "LAW_1", "text": "القانون 1", "type": "LAW"}]
     annotate_structure(structure, entities)
-    assert structure[0]["text"] == "[LAW:القانون 1]"
+    assert structure[0]["text"] == "<القانون 1, id:LAW_1>"
 
 
 def test_insert_brackets_deduplicates():
     text = "القانون 1 القانون 1"
     entities = [
-        {"text": "القانون 1", "type": "LAW"},
-        {"text": "القانون 1", "type": "LAW"},
+        {"id": "LAW_1", "text": "القانون 1", "type": "LAW"},
+        {"id": "LAW_1", "text": "القانون 1", "type": "LAW"},
     ]
     marked = _insert_brackets(text, entities)
-    assert marked.count("[LAW:القانون 1]") == 2
-    assert "[LAW:[LAW:القانون 1]" not in marked
+    assert marked.count("<القانون 1, id:LAW_1>") == 2
+    assert "<<" not in marked
 
 
 def test_annotate_json_metadata():
     data = {"metadata": {"official_title": "القانون 1"}, "structure": []}
-    entities = [{"text": "القانون 1", "type": "LAW"}]
+    entities = [{"id": "LAW_1", "text": "القانون 1", "type": "LAW"}]
     annotate_json(data, entities)
-    assert data["metadata"]["official_title"] == "[LAW:القانون 1]"
+    assert data["metadata"]["official_title"] == "<القانون 1, id:LAW_1>"
 
 
 def test_main_saves_relations(tmp_path, monkeypatch):
@@ -84,3 +84,102 @@ def test_main_saves_relations(tmp_path, monkeypatch):
 
     assert out["relations"] == ner_result["relations"]
     assert out["relations"][0]["target_id"] == "ARTICLE_2"
+
+
+def test_entities_output_without_positions(tmp_path, monkeypatch):
+    input_path = tmp_path / "in.json"
+    output_path = tmp_path / "out.json"
+    ent_path = tmp_path / "entities.json"
+    data = {"structure": [{"text": "المادة 1"}]}
+    with open(input_path, "w", encoding="utf-8") as f:
+        json.dump(data, f)
+
+    ner_result = {
+        "entities": [
+            {
+                "id": "ARTICLE_1",
+                "type": "ARTICLE",
+                "text": "المادة 1",
+                "start_char": 0,
+                "end_char": 7,
+            }
+        ],
+        "relations": [],
+    }
+
+    monkeypatch.setattr(structured_ner, "extract_entities", lambda text, model: ner_result)
+    monkeypatch.setattr(structured_ner, "postprocess_result", lambda text, res: None)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "structured_ner",
+            "--input",
+            str(input_path),
+            "--output",
+            str(output_path),
+            "--entities-output",
+            str(ent_path),
+        ],
+    )
+
+    structured_ner.main()
+
+    with open(ent_path, "r", encoding="utf-8") as f:
+        ents = json.load(f)["entities"]
+
+    assert "start_char" not in ents[0]
+    assert "end_char" not in ents[0]
+
+
+def test_relations_output_without_positions(tmp_path, monkeypatch):
+    input_path = tmp_path / "in.json"
+    output_path = tmp_path / "out.json"
+    ent_path = tmp_path / "entities.json"
+    data = {"structure": [{"text": "المادة 1 تشير"}]}
+    with open(input_path, "w", encoding="utf-8") as f:
+        json.dump(data, f)
+
+    ner_result = {
+        "entities": [],
+        "relations": [
+            {
+                "relation_id": "R1",
+                "type": "refers_to",
+                "source_id": "A",
+                "target_id": "B",
+                "start_char": 0,
+                "end_char": 5,
+                "source": {"id": "A", "start_char": 0, "end_char": 1},
+                "target": {"id": "B", "start_char": 2, "end_char": 3},
+            }
+        ],
+    }
+
+    monkeypatch.setattr(structured_ner, "extract_entities", lambda text, model: ner_result)
+    monkeypatch.setattr(structured_ner, "postprocess_result", lambda text, res: None)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "structured_ner",
+            "--input",
+            str(input_path),
+            "--output",
+            str(output_path),
+            "--entities-output",
+            str(ent_path),
+        ],
+    )
+
+    structured_ner.main()
+
+    with open(ent_path, "r", encoding="utf-8") as f:
+        rels = json.load(f).get("relations", [])
+
+    assert "start_char" not in rels[0]
+    assert "end_char" not in rels[0]
+    assert "start_char" not in rels[0]["source"]
+    assert "end_char" not in rels[0]["source"]
+    assert "start_char" not in rels[0]["target"]
+    assert "end_char" not in rels[0]["target"]


### PR DESCRIPTION
## Summary
- Add recursive utility to strip `start_char`/`end_char` from both entities and relations
- Ensure relations in output JSON and optional entities file are written without positional fields
- Expand test coverage to verify relation positional data is removed

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6897820c8e308324b01799c2322f2bb7