### PR TITLE
Link legislation entities only when relations exist

### DIFF
--- a/tests/test_view_legislation_entities.py
+++ b/tests/test_view_legislation_entities.py
@@ -30,7 +30,41 @@ def test_view_legislation_includes_entities(tmp_path, monkeypatch):
 
     monkeypatch.chdir(tmp_path)
     client = app.test_client()
-    resp = client.get('/legislation?file=test.json')
+    resp = client.get('/legislation?file=test')
     assert resp.status_code == 200
     body = resp.get_data(as_text=True)
     assert 'القانون 1 يشير إلى الفصل 2' in body
+
+
+def test_entity_links_only_when_related(tmp_path, monkeypatch):
+    out_dir = tmp_path / 'output'
+    ner_dir = tmp_path / 'ner_output'
+    out_dir.mkdir()
+    ner_dir.mkdir()
+
+    structure_path = out_dir / 'test.json'
+    with open(structure_path, 'w', encoding='utf-8') as f:
+        json.dump({'text': '<القانون 1, id:1> <الفصل 2, id:2> <شخص ما, id:3>'}, f, ensure_ascii=False)
+
+    ner_data = {
+        'entities': [
+            {'id': 1, 'text': 'القانون 1', 'type': 'LAW'},
+            {'id': 2, 'text': 'الفصل 2', 'type': 'ARTICLE'},
+            {'id': 3, 'text': 'شخص ما', 'type': 'PERSON'},
+        ],
+        'relations': [
+            {'source_id': 1, 'target_id': 2, 'type': 'refers_to'},
+        ],
+    }
+    ner_path = ner_dir / 'test_ner.json'
+    with open(ner_path, 'w', encoding='utf-8') as f:
+        json.dump(ner_data, f, ensure_ascii=False)
+
+    monkeypatch.chdir(tmp_path)
+    client = app.test_client()
+    resp = client.get('/legislation?file=test')
+    assert resp.status_code == 200
+    body = resp.get_data(as_text=True)
+    assert 'href="#entity-1"' in body
+    assert 'href="#entity-2"' in body
+    assert 'href="#entity-3"' not in body


### PR DESCRIPTION
## Summary
- Maintain a mapping between legislation JSON files and their NER outputs to reduce confusion when multiple documents are present
- Load entities and relations via base file names, linking only entities with associated relationships
- Update tests to use the new base-name routing

## Testing
- `pip install flask` *(fails: Could not find a version that satisfies the requirement flask)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689794e7aca08324a044e7afd63b2a91