### PR TITLE
Run structured NER during structure extraction

### DIFF
--- a/tests/test_structured_ner.py
+++ b/tests/test_structured_ner.py
@@ -1,7 +1,7 @@
 import json
 import sys
-import structured_ner
-from structured_ner import _insert_brackets, annotate_structure, annotate_json
+from pipeline import structured_ner
+from pipeline.structured_ner import _insert_brackets, annotate_structure, annotate_json
 
 
 def test_insert_brackets_simple():


### PR DESCRIPTION
## Summary
- Move structured_ner into pipeline package and expose `run_structured_ner`
- Invoke structured NER when processing structure uploads and save NER results
- Update tests to reference new module location

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6897a0111af483248bfab73f359d1763