### PR TITLE
Fix NER file base name parsing

### DIFF
--- a/app.py
+++ b/app.py
@@ -372,7 +372,7 @@ def _collect_documents() -> dict[str, dict[str, str]]:
     if os.path.isdir('ner_output'):
         for f in os.listdir('ner_output'):
             if f.endswith('_ner.json'):
-                base = f[:-8]  # remove '_ner.json'
+                base = f[:-9]  # remove '_ner.json'
                 docs.setdefault(base, {})['ner'] = os.path.join('ner_output', f)
     return docs
 


### PR DESCRIPTION
## Summary
- Fix document collection to properly map NER files to their corresponding structure files by stripping the full `_ner.json` suffix

## Testing
- `pytest -q`
- `pip install flask -q` *(fails: Could not find a version that satisfies the requirement flask)*

------
https://chatgpt.com/codex/tasks/task_e_6897c0f844c883248bffd6c0cb226bbf