### PR TITLE
Strip entity ids from legislation section titles

### DIFF
--- a/templates/legislation.html
+++ b/templates/legislation.html
@@ -137,16 +137,16 @@
         const summary = document.createElement('summary');
         summary.classList.add('json-key');
         let label = '';
-        if (node.type) label += node.type;
+        if (node.type) label += escapeHtml(node.type);
         if (node.number) {
-            label += (label ? ' ' : '') + node.number;
+            label += (label ? ' ' : '') + escapeHtml(node.number);
             const num = canonicalNum(node.number);
             if (num) summary.id = `node-${num}`;
         }
         if (node.title) {
-            label += (label ? ': ' : '') + node.title;
+            label += (label ? ': ' : '') + formatText(node.title);
         }
-        summary.textContent = label || node.text || '';
+        summary.innerHTML = label || formatText(node.text || '');
         details.appendChild(summary);
 
         if (node.text) {


### PR DESCRIPTION
## Summary
- ensure legislation section titles display plain text by removing `<... id:n>` markup
- escape type and number fields to prevent HTML injection

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6897e7fbe3d88324bfc59a2a07314bb3