### PR TITLE
Add annotation_editor-backed editing interface

### DIFF
--- a/templates/edit_annotations.html
+++ b/templates/edit_annotations.html
@@ -1,0 +1,80 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Edit Annotations</title>
+    <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}" />
+</head>
+<body>
+<header>
+    <div class="logo">Legal AI Assistant</div>
+    <nav>
+        <a href="{{ url_for('home') }}">Home</a>
+        <a href="{{ url_for('index') }}">Entities</a>
+        <a href="{{ url_for('extract_structure') }}">Structure</a>
+        <a href="{{ url_for('parse_decision_route') }}">Decision</a>
+        <a href="{{ url_for('run_query') }}">SQL</a>
+        <a href="{{ url_for('view_legislation') }}">Moroccan Legislation</a>
+    </nav>
+</header>
+<main class="container">
+    <h1>Edit Annotations - {{ file }}</h1>
+    {% if error %}<p style="color:red">{{ error }}</p>{% endif %}
+
+    <form method="post">
+        <textarea name="content" rows="20" style="width:100%">{{ content }}</textarea>
+        <p>
+            <button type="submit" name="action" value="save" class="button">Save</button>
+            <a href="{{ url_for('view_legislation', file=file) }}" class="button">Back</a>
+        </p>
+    </form>
+
+    <h2>Entities</h2>
+    <ul>
+    {% for e in entities %}
+        <li>{{ e.id }} - {{ e.type }} - {{ e.text }}</li>
+    {% endfor %}
+    </ul>
+
+    <h2>Operations</h2>
+    <form method="post" class="inline-form">
+        <input type="hidden" name="action" value="add" />
+        <label>Start <input name="start" size="4" /></label>
+        <label>End <input name="end" size="4" /></label>
+        <label>Type <input name="type" size="6" /></label>
+        <label>Norm <input name="norm" size="8" /></label>
+        <button type="submit" class="button">Add</button>
+    </form>
+
+    <form method="post" class="inline-form">
+        <input type="hidden" name="action" value="delete" />
+        <label>ID <input name="id" size="6" /></label>
+        <button type="submit" class="button">Delete</button>
+    </form>
+
+    <form method="post" class="inline-form">
+        <input type="hidden" name="action" value="update" />
+        <label>ID <input name="id" size="6" /></label>
+        <label>Type <input name="type" size="6" /></label>
+        <label>Norm <input name="norm" size="8" /></label>
+        <label>Start <input name="start" size="4" /></label>
+        <label>End <input name="end" size="4" /></label>
+        <button type="submit" class="button">Update</button>
+    </form>
+
+    <form method="post" class="inline-form">
+        <input type="hidden" name="action" value="replace" />
+        <label>Start <input name="start" size="4" /></label>
+        <label>End <input name="end" size="4" /></label>
+        <label>Text <input name="text" size="10" /></label>
+        <button type="submit" class="button">Replace Text</button>
+    </form>
+
+    <form method="post" class="inline-form">
+        <input type="hidden" name="action" value="fix" />
+        <button type="submit" class="button">Fix Offsets</button>
+    </form>
+</main>
+</body>
+</html>

--- a/templates/legislation.html
+++ b/templates/legislation.html
@@ -71,6 +71,9 @@
         </ul>
     </section>
     {% endif %}
+    <section class="card">
+        <a class="button" href="{{ url_for('edit_legislation', file=selected) }}">Edit annotations</a>
+    </section>
     <div id="popup" style="display:none;position:fixed;top:10%;left:10%;width:80%;max-height:80%;overflow:auto;background:white;border:1px solid #888;padding:10px;z-index:1000;">
         <button id="popup-close" style="float:left;">X</button>
         <div id="popup-content"></div>

--- a/tests/test_edit_legislation.py
+++ b/tests/test_edit_legislation.py
@@ -1,0 +1,64 @@
+import json
+import pytest
+
+flask = pytest.importorskip('flask')
+from app import app
+
+
+def _setup_dirs(tmp_path):
+    out_dir = tmp_path / 'output'
+    ner_dir = tmp_path / 'ner_output'
+    txt_dir = tmp_path / 'data_txt'
+    out_dir.mkdir()
+    ner_dir.mkdir()
+    txt_dir.mkdir()
+
+    with open(out_dir / 'test.json', 'w', encoding='utf-8') as f:
+        json.dump({}, f)
+    with open(ner_dir / 'test_ner.json', 'w', encoding='utf-8') as f:
+        json.dump({'entities': [], 'relations': []}, f)
+    with open(txt_dir / 'test.txt', 'w', encoding='utf-8') as f:
+        f.write('abcdef')
+
+    return out_dir, ner_dir, txt_dir
+
+
+def test_edit_legislation_save(tmp_path, monkeypatch):
+    _, ner_dir, _ = _setup_dirs(tmp_path)
+    monkeypatch.chdir(tmp_path)
+    client = app.test_client()
+
+    resp = client.get('/legislation/edit?file=test')
+    assert resp.status_code == 200
+    assert '<textarea' in resp.get_data(as_text=True)
+
+    content = '[[ENT id=1 type=LAW]]abc[[/ENT]]def'
+    resp = client.post('/legislation/edit?file=test', data={'action': 'save', 'content': content})
+    assert resp.status_code == 302
+
+    with open(ner_dir / 'test_ner.json', 'r', encoding='utf-8') as f:
+        data = json.load(f)
+    assert data['entities'][0]['type'] == 'LAW'
+    assert data['entities'][0]['start_char'] == 0
+
+
+def test_edit_legislation_add_delete(tmp_path, monkeypatch):
+    _, ner_dir, _ = _setup_dirs(tmp_path)
+    monkeypatch.chdir(tmp_path)
+    client = app.test_client()
+
+    resp = client.post(
+        '/legislation/edit?file=test',
+        data={'action': 'add', 'start': '0', 'end': '3', 'type': 'LAW'},
+    )
+    assert resp.status_code == 200
+    with open(ner_dir / 'test_ner.json', 'r', encoding='utf-8') as f:
+        data = json.load(f)
+    assert data['entities'][0]['text'] == 'abc'
+    eid = data['entities'][0]['id']
+
+    resp = client.post('/legislation/edit?file=test', data={'action': 'delete', 'id': str(eid)})
+    assert resp.status_code == 200
+    with open(ner_dir / 'test_ner.json', 'r', encoding='utf-8') as f:
+        data = json.load(f)
+    assert data['entities'] == []


### PR DESCRIPTION
## Summary
- integrate annotation_editor utilities and helpers for loading and saving annotation data
- extend `/legislation/edit` to support add, delete, update, replace-text and offset-fix actions
- expand annotation editor template and tests to cover new operations

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6897eb780cec8324a6c3c3d06ed4367a