### PR TITLE
Improve annotation editor with interactive UI

### DIFF
--- a/static/annotations.js
+++ b/static/annotations.js
@@ -1,0 +1,59 @@
+document.addEventListener('DOMContentLoaded', () => {
+    const textDiv = document.getElementById('text-display');
+    const addStart = document.getElementById('add-start');
+    const addEnd = document.getElementById('add-end');
+    const updId = document.getElementById('upd-id');
+    const updType = document.getElementById('upd-type');
+    const updNorm = document.getElementById('upd-norm');
+    const updStart = document.getElementById('upd-start');
+    const updEnd = document.getElementById('upd-end');
+    const repStart = document.getElementById('rep-start');
+    const repEnd = document.getElementById('rep-end');
+
+    function getOffset(node, offset) {
+        const range = document.createRange();
+        range.selectNodeContents(textDiv);
+        range.setEnd(node, offset);
+        return range.toString().length;
+    }
+
+    textDiv.addEventListener('mouseup', () => {
+        const sel = window.getSelection();
+        if (!sel || sel.rangeCount === 0) return;
+        const range = sel.getRangeAt(0);
+        if (!textDiv.contains(range.startContainer) || !textDiv.contains(range.endContainer)) return;
+        const start = getOffset(range.startContainer, range.startOffset);
+        const end = getOffset(range.endContainer, range.endOffset);
+        addStart.value = start;
+        addEnd.value = end;
+        repStart.value = start;
+        repEnd.value = end;
+    });
+
+    document.querySelectorAll('.entity-mark').forEach(span => {
+        span.addEventListener('click', () => {
+            document.querySelectorAll('.entity-mark').forEach(s => s.classList.remove('selected'));
+            span.classList.add('selected');
+            updId.value = span.dataset.id;
+            updType.value = span.dataset.type || '';
+            updNorm.value = span.dataset.norm || '';
+            updStart.value = span.dataset.start;
+            updEnd.value = span.dataset.end;
+        });
+    });
+
+    document.querySelectorAll('.edit-entity').forEach(btn => {
+        btn.addEventListener('click', () => {
+            const tr = btn.closest('tr');
+            if (!tr) return;
+            document.querySelectorAll('.entity-mark').forEach(s => s.classList.remove('selected'));
+            const span = document.querySelector(`.entity-mark[data-id="${tr.dataset.id}"]`);
+            if (span) span.classList.add('selected');
+            updId.value = tr.dataset.id;
+            updType.value = tr.dataset.type || '';
+            updNorm.value = tr.dataset.norm || '';
+            updStart.value = tr.dataset.start;
+            updEnd.value = tr.dataset.end;
+        });
+    });
+});

--- a/static/style.css
+++ b/static/style.css
@@ -155,6 +155,38 @@ pre {
     background-color: orange;
 }
 
+table {
+    width: 100%;
+    border-collapse: collapse;
+    margin-top: 10px;
+}
+
+th, td {
+    border: 1px solid #ccc;
+    padding: 6px;
+    text-align: left;
+}
+
+th {
+    background-color: var(--primary);
+    color: #fff;
+}
+
+tr:nth-child(even) {
+    background-color: #f9f9f9;
+}
+
+.button.small {
+    padding: 4px 8px;
+    font-size: 0.8rem;
+    margin-top: 0;
+}
+
+.inline-form {
+    display: inline-block;
+    margin-right: 10px;
+}
+
 .json-tree ul {
     list-style: none;
     margin-left: 20px;

--- a/templates/edit_annotations.html
+++ b/templates/edit_annotations.html
@@ -22,59 +22,73 @@
     <h1>Edit Annotations - {{ file }}</h1>
     {% if error %}<p style="color:red">{{ error }}</p>{% endif %}
 
-    <form method="post">
-        <textarea name="content" rows="20" style="width:100%">{{ content }}</textarea>
-        <p>
-            <button type="submit" name="action" value="save" class="button">Save</button>
-            <a href="{{ url_for('view_legislation', file=file) }}" class="button">Back</a>
-        </p>
-    </form>
-
-    <h2>Entities</h2>
-    <ul>
-    {% for e in entities %}
-        <li>{{ e.id }} - {{ e.type }} - {{ e.text }}</li>
-    {% endfor %}
-    </ul>
+    <div id="text-display" class="card" dir="rtl">{{ content|safe }}</div>
 
     <h2>Operations</h2>
-    <form method="post" class="inline-form">
+    <form id="add-form" method="post" class="inline-form">
         <input type="hidden" name="action" value="add" />
-        <label>Start <input name="start" size="4" /></label>
-        <label>End <input name="end" size="4" /></label>
+        <label>Start <input id="add-start" name="start" size="4" /></label>
+        <label>End <input id="add-end" name="end" size="4" /></label>
         <label>Type <input name="type" size="6" /></label>
         <label>Norm <input name="norm" size="8" /></label>
         <button type="submit" class="button">Add</button>
     </form>
 
-    <form method="post" class="inline-form">
-        <input type="hidden" name="action" value="delete" />
-        <label>ID <input name="id" size="6" /></label>
-        <button type="submit" class="button">Delete</button>
-    </form>
-
-    <form method="post" class="inline-form">
+    <form id="update-form" method="post" class="inline-form">
         <input type="hidden" name="action" value="update" />
-        <label>ID <input name="id" size="6" /></label>
-        <label>Type <input name="type" size="6" /></label>
-        <label>Norm <input name="norm" size="8" /></label>
-        <label>Start <input name="start" size="4" /></label>
-        <label>End <input name="end" size="4" /></label>
+        <label>ID <input id="upd-id" name="id" size="6" /></label>
+        <label>Type <input id="upd-type" name="type" size="6" /></label>
+        <label>Norm <input id="upd-norm" name="norm" size="8" /></label>
+        <label>Start <input id="upd-start" name="start" size="4" /></label>
+        <label>End <input id="upd-end" name="end" size="4" /></label>
         <button type="submit" class="button">Update</button>
     </form>
 
-    <form method="post" class="inline-form">
+    <form id="replace-form" method="post" class="inline-form">
         <input type="hidden" name="action" value="replace" />
-        <label>Start <input name="start" size="4" /></label>
-        <label>End <input name="end" size="4" /></label>
-        <label>Text <input name="text" size="10" /></label>
+        <label>Start <input id="rep-start" name="start" size="4" /></label>
+        <label>End <input id="rep-end" name="end" size="4" /></label>
+        <label>Text <input id="rep-text" name="text" size="10" /></label>
         <button type="submit" class="button">Replace Text</button>
     </form>
 
     <form method="post" class="inline-form">
         <input type="hidden" name="action" value="fix" />
         <button type="submit" class="button">Fix Offsets</button>
+        <a href="{{ url_for('view_legislation', file=file) }}" class="button">Back</a>
+    </form>
+
+    <h2>Entities</h2>
+    <table id="entity-table">
+        <thead>
+            <tr><th>ID</th><th>Type</th><th>Text</th><th>Actions</th></tr>
+        </thead>
+        <tbody>
+        {% for e in entities %}
+            <tr data-id="{{ e.id }}" data-type="{{ e.type }}" data-norm="{{ e.normalized }}" data-start="{{ e.start_char }}" data-end="{{ e.end_char }}">
+                <td>{{ e.id }}</td>
+                <td>{{ e.type }}</td>
+                <td>{{ e.text }}</td>
+                <td>
+                    <form method="post" class="inline-form">
+                        <input type="hidden" name="action" value="delete" />
+                        <input type="hidden" name="id" value="{{ e.id }}" />
+                        <button type="submit" class="button small">Delete</button>
+                    </form>
+                    <button type="button" class="button small edit-entity">Edit</button>
+                </td>
+            </tr>
+        {% endfor %}
+        </tbody>
+    </table>
+
+    <h2>Raw Content</h2>
+    <form method="post">
+        <input type="hidden" name="action" value="save" />
+        <textarea name="content" rows="10" style="width:100%">{{ raw }}</textarea>
+        <button type="submit" class="button">Save</button>
     </form>
 </main>
+<script src="{{ url_for('static', filename='annotations.js') }}"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- render editable HTML spans with entity metadata to simplify offset handling
- replace raw forms with interactive annotation table and auto-filled start/end positions
- add JavaScript and CSS for selection-based editing and streamlined controls

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6897f33b450c8324a468ab1a7fc994d3