### PR TITLE
feat: show structured legislation in annotation editor

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,5 +1,4 @@
 import os
-import html
 import json
 import re
 import tempfile
@@ -416,36 +415,6 @@ def _save_annotation(text: str, entities: list[dict], relations: list[dict], txt
         json.dump({'entities': entities, 'relations': relations}, f, ensure_ascii=False, indent=2)
 
 
-def _render_editable_html(text: str, entities: list[dict]) -> str:
-    """Return HTML with entity spans annotated for the editor."""
-    parts: list[str] = []
-    last = 0
-    for ent in sorted(entities, key=lambda e: int(e.get("start_char", 0))):
-        try:
-            start = int(ent.get("start_char", -1))
-            end = int(ent.get("end_char", -1))
-        except Exception:
-            continue
-        if start < last or start < 0 or end <= start or end > len(text):
-            continue
-        parts.append(html.escape(text[last:start]))
-        span_text = html.escape(text[start:end])
-        attrs = [
-            f'data-id="{html.escape(str(ent.get("id")))}"',
-            f'data-type="{html.escape(str(ent.get("type")))}"',
-            f'data-start="{start}"',
-            f'data-end="{end}"',
-        ]
-        norm = ent.get("normalized")
-        if norm:
-            attrs.append(f'data-norm="{html.escape(str(norm))}"')
-        attr_str = " ".join(attrs)
-        parts.append(f'<span class="entity-mark" {attr_str}>{span_text}</span>')
-        last = end
-    parts.append(html.escape(text[last:]))
-    return ''.join(parts)
-
-
 @app.route('/legislation')
 def view_legislation():
     docs = _collect_documents()
@@ -494,6 +463,13 @@ def edit_legislation():
     if name not in docs:
         return "File not found", 404
 
+    doc = docs.get(name, {})
+    structure_path = doc.get('structure')
+    structure = None
+    if structure_path and os.path.exists(structure_path):
+        with open(structure_path, 'r', encoding='utf-8') as sf:
+            structure = json.load(sf)
+
     text, entities, relations, txt_path, ner_path = _load_annotation(name)
 
     if request.method == 'POST':
@@ -506,11 +482,10 @@ def edit_legislation():
                 _save_annotation(text, entities, relations, txt_path, ner_path)
                 return redirect(url_for('view_legislation', file=name))
             except Exception as exc:
-                html_view = _render_editable_html(text, entities)
                 return render_template(
                     'edit_annotations.html',
                     file=name,
-                    content=html_view,
+                    data=structure,
                     raw=content,
                     entities=entities,
                     error=str(exc),
@@ -552,22 +527,20 @@ def edit_legislation():
             ae_fix_offsets(text, {'entities': entities})
 
         _save_annotation(text, entities, relations, txt_path, ner_path)
-        html_view = _render_editable_html(text, entities)
         annotated = ae_text_with_markers(text, entities)
         return render_template(
             'edit_annotations.html',
             file=name,
-            content=html_view,
+            data=structure,
             raw=annotated,
             entities=entities,
             error=None,
         )
-    html_view = _render_editable_html(text, entities)
     annotated = ae_text_with_markers(text, entities)
     return render_template(
         'edit_annotations.html',
         file=name,
-        content=html_view,
+        data=structure,
         raw=annotated,
         entities=entities,
         error=None,

--- a/static/annotations.js
+++ b/static/annotations.js
@@ -66,7 +66,8 @@ document.addEventListener('DOMContentLoaded', () => {
     });
 
     document.querySelectorAll('.entity-mark').forEach(span => {
-        span.addEventListener('click', () => {
+        span.addEventListener('click', ev => {
+            ev.stopPropagation();
             document.querySelectorAll('.entity-mark').forEach(s => s.classList.remove('selected'));
             span.classList.add('selected');
             updId.value = span.dataset.id;

--- a/templates/edit_annotations.html
+++ b/templates/edit_annotations.html
@@ -22,7 +22,7 @@
     <h1>Edit Annotations - {{ file }}</h1>
     {% if error %}<p style="color:red">{{ error }}</p>{% endif %}
 
-    <div id="text-display" class="card" dir="rtl">{{ content|safe }}</div>
+    <div id="text-display" class="card"><div id="json-tree" dir="rtl"></div></div>
 
     <h2>Operations</h2>
     <form id="add-form" method="post" class="inline-form">
@@ -97,6 +97,75 @@
         <button type="submit" class="button">Save</button>
     </form>
 </main>
+<script>
+    const data = {{ data | tojson }};
+    const entitiesData = {{ entities | tojson }};
+    const entityMap = {};
+    entitiesData.forEach(e => { entityMap[e.id] = e; });
+
+    function escapeHtml(str) {
+        return String(str).replace(/[&<>"']/g, c => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;','\'':'&#39;'}[c]));
+    }
+
+    function formatText(value) {
+        if (typeof value !== 'string') return escapeHtml(value);
+        return value.replace(/<([^,<>]+), id:(\d+)>/g, (_m, txt, id) => {
+            const ent = entityMap[id] || {};
+            const attrs = [`class=\"entity-mark\"`,`data-id=\"${id}\"`,`data-start=\"${ent.start_char || 0}\"`,`data-end=\"${ent.end_char || 0}\"`];
+            if (ent.type) attrs.push(`data-type=\"${escapeHtml(ent.type)}\"`);
+            if (ent.normalized) attrs.push(`data-norm=\"${escapeHtml(ent.normalized)}\"`);
+            return `<span ${attrs.join(' ')}>${escapeHtml(txt)}</span>`;
+        });
+    }
+
+    function renderNode(node, container) {
+        const details = document.createElement('details');
+        const summary = document.createElement('summary');
+        summary.classList.add('json-key');
+        let label = '';
+        if (node.type) label += escapeHtml(node.type);
+        if (node.number) label += (label ? ' ' : '') + escapeHtml(node.number);
+        if (node.title) label += (label ? ': ' : '') + formatText(node.title);
+        summary.innerHTML = label;
+        details.appendChild(summary);
+
+        if (node.text) {
+            const textDiv = document.createElement('div');
+            textDiv.className = 'json-value';
+            textDiv.innerHTML = formatText(node.text);
+            details.appendChild(textDiv);
+        }
+
+        if (Array.isArray(node.children) && node.children.length) {
+            const ul = document.createElement('ul');
+            node.children.forEach(child => {
+                const li = document.createElement('li');
+                renderNode(child, li);
+                ul.appendChild(li);
+            });
+            details.appendChild(ul);
+        }
+        container.appendChild(details);
+    }
+
+    function render(container, obj) {
+        if (Array.isArray(obj)) {
+            const ul = document.createElement('ul');
+            obj.forEach(item => {
+                const li = document.createElement('li');
+                renderNode(item, li);
+                ul.appendChild(li);
+            });
+            container.appendChild(ul);
+        } else if (obj && typeof obj === 'object') {
+            renderNode(obj, container);
+        }
+    }
+
+    if (data) {
+        render(document.getElementById('json-tree'), data);
+    }
+</script>
 <script src="{{ url_for('static', filename='annotations.js') }}"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- display legislation tree instead of raw text when editing annotations
- load document structure and render clickable entity spans
- prevent detail toggling when selecting entities

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6897fcc7abc483248626ceac15c6051c