### PR TITLE
Display full structure tree in annotation editor

### DIFF
--- a/templates/edit_annotations.html
+++ b/templates/edit_annotations.html
@@ -98,7 +98,7 @@
     </form>
 </main>
 <script>
-    const data = {{ data | tojson }};
+    const rawData = {{ data | tojson }};
     const entitiesData = {{ entities | tojson }};
     const entityMap = {};
     entitiesData.forEach(e => { entityMap[e.id] = e; });
@@ -147,6 +147,31 @@
         }
         container.appendChild(details);
     }
+
+    function toNode(key, value) {
+        if (value === null || typeof value !== 'object') {
+            return { type: key, text: String(value) };
+        }
+        if (Array.isArray(value)) {
+            return { type: key, children: value.map((v, i) => toNode(String(i), v)) };
+        }
+        if (value.type) {
+            const node = { type: value.type };
+            if (value.number) node.number = value.number;
+            if (value.title) node.title = value.title;
+            if (value.text) node.text = value.text;
+            if (Array.isArray(value.children)) {
+                node.children = value.children.map((c, i) => toNode(String(i), c));
+            }
+            return node;
+        }
+        return {
+            type: key,
+            children: Object.entries(value).map(([k, v]) => toNode(k, v)),
+        };
+    }
+
+    const data = toNode('{{ file }}', rawData);
 
     function render(container, obj) {
         if (Array.isArray(obj)) {


### PR DESCRIPTION
## Summary
- Convert raw legislation JSON into a hierarchical node tree so the entire structure appears in the annotation editor

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6897ff3218c08324b2cd0ddc82d38baf