### PR TITLE
feat: add draggable entity handles

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -155,6 +155,24 @@ pre {
     background-color: orange;
 }
 
+/* Floating arrows for adjusting entity boundaries */
+.entity-handle {
+    position: absolute;
+    background: #fff;
+    border: 1px solid #888;
+    border-radius: 4px;
+    padding: 2px;
+    z-index: 100;
+}
+
+.entity-handle button {
+    border: none;
+    background: transparent;
+    cursor: pointer;
+    padding: 0 2px;
+    font-size: 12px;
+}
+
 table {
     width: 100%;
     border-collapse: collapse;


### PR DESCRIPTION
## Summary
- show floating arrow handles when selecting an entity
- allow adjusting entity start/end directly via arrow handles
- style handle controls for clarity

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6898048bedf88324af6eee030584531d