### PR TITLE
feat: add draggable entity handles

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -155,6 +155,28 @@ pre {
     background-color: orange;
 }
 
+/* Floating arrows for adjusting entity boundaries */
+.entity-handle {
+    position: absolute;
+    width: 0;
+    height: 0;
+    z-index: 100;
+}
+
+.entity-handle.start {
+    border-top: 8px solid transparent;
+    border-bottom: 8px solid transparent;
+    border-right: 10px solid var(--accent);
+    cursor: col-resize;
+}
+
+.entity-handle.end {
+    border-top: 8px solid transparent;
+    border-bottom: 8px solid transparent;
+    border-left: 10px solid var(--accent);
+    cursor: col-resize;
+}
+
 table {
     width: 100%;
     border-collapse: collapse;


### PR DESCRIPTION
## Summary
- show draggable arrow handles above a selected entity
- update entity start/end as the arrows are dragged
- style triangular handles for better visibility

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6898048bedf88324af6eee030584531d