### PR TITLE
Enable draggable brackets for entity editing

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -155,22 +155,14 @@ pre {
     background-color: orange;
 }
 
-/* Floating arrows for adjusting entity boundaries */
+/* Floating handles for adjusting entity boundaries */
 .entity-handle {
     position: absolute;
-    background: #fff;
-    border: 1px solid #888;
-    border-radius: 4px;
-    padding: 2px;
     z-index: 100;
-}
-
-.entity-handle button {
-    border: none;
-    background: transparent;
-    cursor: pointer;
-    padding: 0 2px;
-    font-size: 12px;
+    font-weight: bold;
+    cursor: ew-resize;
+    user-select: none;
+    color: red;
 }
 
 table {


### PR DESCRIPTION
## Summary
- Replace start/end handles with bracket markers that can be dragged to adjust entity boundaries.
- Style new handles without white boxes for a cleaner UI.

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689808ab14488324b4afd71abad43970