### PR TITLE
Fix movable annotation handles alignment

### DIFF
--- a/static/annotations.js
+++ b/static/annotations.js
@@ -37,7 +37,7 @@ document.addEventListener('DOMContentLoaded', () => {
         }
         const rect = span.getBoundingClientRect();
         const handleH = startHandle.offsetHeight || 20;
-        const top = window.scrollY + rect.top - handleH;
+        const top = window.scrollY + rect.top + (rect.height - handleH) / 2;
         startHandle.style.top = `${top}px`;
         startHandle.style.left = `${window.scrollX + rect.left}px`;
         endHandle.style.top = `${top}px`;


### PR DESCRIPTION
## Summary
- Center annotation boundary handles on selected text instead of above it, allowing easier dragging

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68980b5ce91883248d3a186e4e19ccfe