### PR TITLE
Add popup for changing annotation types and improve drag handles

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -165,6 +165,21 @@ pre {
     color: red;
 }
 
+/* Popup for changing annotation type */
+.annotation-popup {
+    position: absolute;
+    z-index: 200;
+    background: #fff;
+    border: 1px solid #ccc;
+    padding: 4px;
+    border-radius: 4px;
+    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.2);
+}
+
+.annotation-popup select {
+    font-size: 0.9rem;
+}
+
 table {
     width: 100%;
     border-collapse: collapse;


### PR DESCRIPTION
## Summary
- show a popup with available annotation types when clicking an entity
- support pointer-based dragging for entity boundary handles
- style popup for visibility

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68980fc56c548324a2b765e4ae59826f