### PR TITLE
fix: prevent text selection when dragging handles

### DIFF
--- a/static/annotations.js
+++ b/static/annotations.js
@@ -137,6 +137,10 @@ document.addEventListener('DOMContentLoaded', () => {
             dragTarget = handle === startHandle ? 'start' : 'end';
             pendingHandle = null;
             wasDragging = false;
+            // Disable text selection while dragging the handles so the
+            // mouse movement adjusts entity offsets instead of creating a
+            // new selection range in the document.
+            textDiv.style.userSelect = 'none';
             if (handle.setPointerCapture && ev.pointerId !== undefined) {
                 handle.setPointerCapture(ev.pointerId);
             }
@@ -155,6 +159,7 @@ document.addEventListener('DOMContentLoaded', () => {
         if (!dragTarget) return;
         const selected = document.querySelector('.entity-mark.selected');
         if (!selected) return;
+        ev.preventDefault();
         const offset = getOffsetFromCoords(ev.clientX, ev.clientY);
         if (offset == null) return;
         let start = parseInt(updStart.value || '0', 10);
@@ -176,7 +181,11 @@ document.addEventListener('DOMContentLoaded', () => {
     document.addEventListener('mousemove', moveHandler);
     document.addEventListener('pointermove', moveHandler);
 
-    const endDrag = () => { dragTarget = null; };
+    const endDrag = () => {
+        dragTarget = null;
+        // Re-enable text selection after the drag completes.
+        textDiv.style.userSelect = '';
+    };
     document.addEventListener('mouseup', endDrag);
     document.addEventListener('pointerup', endDrag);
 


### PR DESCRIPTION
## Summary
- avoid creating a text selection when dragging annotation brackets
- keep start/end inputs synced with bracket movement and re-enable selection after drag

## Testing
- `pytest tests/test_edit_legislation.py -q` *(fails: 1 skipped)*


------
https://chatgpt.com/codex/tasks/task_e_68981d9c2e948324bfb6e884594525fd