### PR TITLE
Store entity brackets without offsets

### DIFF
--- a/static/annotations.js
+++ b/static/annotations.js
@@ -1,6 +1,19 @@
 document.addEventListener('DOMContentLoaded', () => {
     const textDiv = document.getElementById('text-display');
 
+    function initOffsets() {
+        document.querySelectorAll('.entity-mark').forEach(span => {
+            const range = document.createRange();
+            range.selectNodeContents(textDiv);
+            range.setEndBefore(span);
+            const start = range.toString().length;
+            const end = start + span.textContent.length;
+            span.dataset.start = start;
+            span.dataset.end = end;
+        });
+    }
+    initOffsets();
+
     const availableTypes = Array.from(
         new Set(Array.from(document.querySelectorAll('.entity-mark'))
             .map(s => s.dataset.type)
@@ -38,8 +51,8 @@ document.addEventListener('DOMContentLoaded', () => {
         const fd = new FormData();
         fd.append('action', 'update');
         fd.append('id', span.dataset.id);
-        fd.append('start', span.dataset.start);
-        fd.append('end', span.dataset.end);
+        if (span.dataset.start !== undefined) fd.append('start', span.dataset.start);
+        if (span.dataset.end !== undefined) fd.append('end', span.dataset.end);
         if (span.dataset.type) fd.append('type', span.dataset.type);
         if (span.dataset.norm) fd.append('norm', span.dataset.norm);
         fetch(window.location.pathname + window.location.search, { method: 'POST', body: fd });
@@ -105,8 +118,14 @@ document.addEventListener('DOMContentLoaded', () => {
             hideHandles();
             return;
         }
-        const startRect = getRectAtOffset(parseInt(span.dataset.start, 10));
-        const endRect = getRectAtOffset(parseInt(span.dataset.end, 10));
+        const start = parseInt(span.dataset.start, 10);
+        const end = parseInt(span.dataset.end, 10);
+        if (Number.isNaN(start) || Number.isNaN(end)) {
+            hideHandles();
+            return;
+        }
+        const startRect = getRectAtOffset(start);
+        const endRect = getRectAtOffset(end);
         if (!startRect || !endRect) {
             hideHandles();
             return;
@@ -249,8 +268,14 @@ document.addEventListener('DOMContentLoaded', () => {
             document.querySelectorAll('.entity-mark').forEach(s => s.classList.remove('selected'));
             span.classList.add('selected');
             currentSpan = span;
-            setSelectionRange(parseInt(span.dataset.start, 10), parseInt(span.dataset.end, 10));
-            positionHandles(span);
+            const start = parseInt(span.dataset.start, 10);
+            const end = parseInt(span.dataset.end, 10);
+            if (!Number.isNaN(start) && !Number.isNaN(end)) {
+                setSelectionRange(start, end);
+                positionHandles(span);
+            } else {
+                hideHandles();
+            }
             showTypePopup(span);
         });
     });
@@ -261,11 +286,17 @@ document.addEventListener('DOMContentLoaded', () => {
             if (!tr) return;
             document.querySelectorAll('.entity-mark').forEach(s => s.classList.remove('selected'));
             const span = document.querySelector(`.entity-mark[data-id="${tr.dataset.id}"]`);
-            if (span) span.classList.add('selected');
-            currentSpan = span;
             if (span) {
-                setSelectionRange(parseInt(span.dataset.start, 10), parseInt(span.dataset.end, 10));
-                positionHandles(span);
+                span.classList.add('selected');
+                currentSpan = span;
+                const start = parseInt(span.dataset.start, 10);
+                const end = parseInt(span.dataset.end, 10);
+                if (!Number.isNaN(start) && !Number.isNaN(end)) {
+                    setSelectionRange(start, end);
+                    positionHandles(span);
+                } else {
+                    hideHandles();
+                }
             }
         });
     });

--- a/templates/edit_annotations.html
+++ b/templates/edit_annotations.html
@@ -32,7 +32,7 @@
         </thead>
         <tbody>
         {% for e in entities %}
-            <tr data-id="{{ e.id }}" data-type="{{ e.type }}" data-norm="{{ e.normalized }}" data-start="{{ e.start_char }}" data-end="{{ e.end_char }}">
+            <tr data-id="{{ e.id }}" data-type="{{ e.type }}" data-norm="{{ e.normalized }}">
                 <td>{{ e.id }}</td>
                 <td>{{ e.type }}</td>
                 <td>{{ e.text }}</td>
@@ -64,7 +64,7 @@
         if (typeof value !== 'string') return escapeHtml(value);
         return value.replace(/<([^,<>]+), id:(\d+)>/g, (_m, txt, id) => {
             const ent = entityMap[id] || {};
-            const attrs = [`class=\"entity-mark\"`,`data-id=\"${id}\"`,`data-start=\"${ent.start_char || 0}\"`,`data-end=\"${ent.end_char || 0}\"`];
+            const attrs = [`class=\"entity-mark\"`, `data-id=\"${id}\"`];
             if (ent.type) attrs.push(`data-type=\"${escapeHtml(ent.type)}\"`);
             if (ent.normalized) attrs.push(`data-norm=\"${escapeHtml(ent.normalized)}\"`);
             return `<span ${attrs.join(' ')}>${escapeHtml(txt)}</span>`;

--- a/tests/test_edit_legislation.py
+++ b/tests/test_edit_legislation.py
@@ -30,7 +30,7 @@ def test_edit_legislation_save(tmp_path, monkeypatch):
 
     resp = client.get('/legislation/edit?file=test')
     assert resp.status_code == 200
-    assert '<textarea' in resp.get_data(as_text=True)
+    assert 'entity-table' in resp.get_data(as_text=True)
 
     content = '[[ENT id=1 type=LAW]]abc[[/ENT]]def'
     resp = client.post('/legislation/edit?file=test', data={'action': 'save', 'content': content})
@@ -39,7 +39,8 @@ def test_edit_legislation_save(tmp_path, monkeypatch):
     with open(ner_dir / 'test_ner.json', 'r', encoding='utf-8') as f:
         data = json.load(f)
     assert data['entities'][0]['type'] == 'LAW'
-    assert data['entities'][0]['start_char'] == 0
+    assert data['entities'][0]['text'] == 'abc'
+    assert 'start_char' not in data['entities'][0]
 
 
 def test_edit_legislation_add_delete(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- compute entity offsets from raw text on load instead of relying on stored positions
- save annotations without start/end fields while updating entity text
- infer span offsets client-side so bracket handles work without persisted data

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6898c5e6c5b48324ab1d56e318fbe082