### PR TITLE
Fix entity rendering for alphanumeric IDs

### DIFF
--- a/static/annotations.js
+++ b/static/annotations.js
@@ -337,5 +337,22 @@ document.addEventListener('DOMContentLoaded', () => {
             }
         });
     });
+
+    document.querySelectorAll('.entity-mark').forEach(span => {
+        span.addEventListener('click', () => {
+            document.querySelectorAll('.entity-mark').forEach(s => s.classList.remove('selected'));
+            span.classList.add('selected');
+            currentSpan = span;
+            const start = parseInt(span.dataset.start, 10);
+            const end = parseInt(span.dataset.end, 10);
+            if (!Number.isNaN(start) && !Number.isNaN(end)) {
+                setSelectionRange(start, end);
+                positionHandles(span);
+            } else {
+                hideHandles();
+            }
+            showTypePopup(span);
+        });
+    });
 });
 

--- a/templates/edit_annotations.html
+++ b/templates/edit_annotations.html
@@ -63,7 +63,7 @@
 
     function formatText(value) {
         if (typeof value !== 'string') return escapeHtml(value);
-        return value.replace(/<([^,<>]+), id:(\d+)>/g, (_m, txt, id) => {
+        return value.replace(/<([^,<>]+), id:([^>]+)>/g, (_m, txt, id) => {
             const ent = entityMap[id] || {};
             const attrs = [`class=\"entity-mark\"`, `data-id=\"${id}\"`];
             if (ent.type) attrs.push(`data-type=\"${escapeHtml(ent.type)}\"`);

--- a/templates/legislation.html
+++ b/templates/legislation.html
@@ -120,7 +120,7 @@
         if (typeof value !== 'string') {
             return escapeHtml(String(value));
         }
-        return value.replace(/<([^,<>]+), id:(\d+)>/g, function(_m, txt, id) {
+        return value.replace(/<([^,<>]+), id:([^>]+)>/g, function(_m, txt, id) {
             const ent = entityMap[id];
             const bold = `<strong>${escapeHtml(txt)}</strong>`;
             const target = articleTargets[id];

--- a/tests/test_edit_annotations.py
+++ b/tests/test_edit_annotations.py
@@ -1,0 +1,33 @@
+import json
+import pytest
+
+flask = pytest.importorskip('flask')
+from app import app
+
+def test_edit_legislation_handles_alphanumeric_ids(tmp_path, monkeypatch):
+    out_dir = tmp_path / 'output'
+    ner_dir = tmp_path / 'ner_output'
+    txt_dir = tmp_path / 'data_txt'
+    out_dir.mkdir()
+    ner_dir.mkdir()
+    txt_dir.mkdir()
+
+    # Structure contains an entity marker with alphanumeric ID
+    structure_path = out_dir / 'test.json'
+    with open(structure_path, 'w', encoding='utf-8') as f:
+        json.dump({'text': '<القانون 1, id:LAW_1>'}, f, ensure_ascii=False)
+
+    # Raw text and NER data for the editor
+    with open(txt_dir / 'test.txt', 'w', encoding='utf-8') as f:
+        f.write('القانون 1')
+    ner_data = {'entities': [{'id': 'LAW_1', 'text': 'القانون 1', 'type': 'LAW'}], 'relations': []}
+    with open(ner_dir / 'test_ner.json', 'w', encoding='utf-8') as f:
+        json.dump(ner_data, f, ensure_ascii=False)
+
+    monkeypatch.chdir(tmp_path)
+    client = app.test_client()
+    resp = client.get('/legislation/edit?file=test')
+    assert resp.status_code == 200
+    body = resp.get_data(as_text=True)
+    assert 'class="entity-mark"' in body
+    assert 'data-id="LAW_1"' in body


### PR DESCRIPTION
## Summary
- Support alphanumeric entity IDs in annotation and legislation views
- Add regression test for editing annotations with alphanumeric IDs

## Testing
- `pytest -q`
- `python -m pip install flask -q` *(fails: Could not find a version that satisfies the requirement flask)*

------
https://chatgpt.com/codex/tasks/task_e_6898cdab560c8324910cd4dd0381bf65