### PR TITLE
Fix navigation links to use home endpoint

### DIFF
--- a/templates/corpus.html
+++ b/templates/corpus.html
@@ -10,7 +10,7 @@
 <aside class="sidebar" data-collapsed="false">
   <button class="sidebar-toggle btn ghost" aria-label="Toggle sidebar">☰</button>
   <nav>
-    <a href="{{ url_for('dashboard') }}" class="nav-link">Dashboard</a>
+    <a href="{{ url_for('home') }}" class="nav-link">Dashboard</a>
     <a href="{{ url_for('corpus') }}" class="nav-link active">Corpus</a>
     <a href="{{ url_for('document') }}" class="nav-link">Document</a>
     <a href="{{ url_for('graph_page') }}" class="nav-link">Graph</a>

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -10,7 +10,7 @@
 <aside class="sidebar" data-collapsed="false">
   <button class="sidebar-toggle btn ghost" aria-label="Toggle sidebar">☰</button>
   <nav>
-    <a href="{{ url_for('dashboard') }}" class="nav-link active">Dashboard</a>
+    <a href="{{ url_for('home') }}" class="nav-link active">Dashboard</a>
     <a href="{{ url_for('corpus') }}" class="nav-link">Corpus</a>
     <a href="{{ url_for('document') }}" class="nav-link">Document</a>
     <a href="{{ url_for('graph_page') }}" class="nav-link">Graph</a>

--- a/templates/document.html
+++ b/templates/document.html
@@ -10,7 +10,7 @@
 <aside class="sidebar" data-collapsed="false">
   <button class="sidebar-toggle btn ghost" aria-label="Toggle sidebar">☰</button>
   <nav>
-    <a href="{{ url_for('dashboard') }}" class="nav-link">Dashboard</a>
+    <a href="{{ url_for('home') }}" class="nav-link">Dashboard</a>
     <a href="{{ url_for('corpus') }}" class="nav-link">Corpus</a>
     <a href="{{ url_for('document') }}" class="nav-link active">Document</a>
     <a href="{{ url_for('graph_page') }}" class="nav-link">Graph</a>

--- a/templates/graph.html
+++ b/templates/graph.html
@@ -10,7 +10,7 @@
 <aside class="sidebar" data-collapsed="false">
   <button class="sidebar-toggle btn ghost" aria-label="Toggle sidebar">☰</button>
   <nav>
-    <a href="{{ url_for('dashboard') }}" class="nav-link">Dashboard</a>
+    <a href="{{ url_for('home') }}" class="nav-link">Dashboard</a>
     <a href="{{ url_for('corpus') }}" class="nav-link">Corpus</a>
     <a href="{{ url_for('document') }}" class="nav-link">Document</a>
     <a href="{{ url_for('graph_page') }}" class="nav-link active">Graph</a>

--- a/templates/pipelines.html
+++ b/templates/pipelines.html
@@ -10,7 +10,7 @@
 <aside class="sidebar" data-collapsed="false">
   <button class="sidebar-toggle btn ghost" aria-label="Toggle sidebar">☰</button>
   <nav>
-    <a href="{{ url_for('dashboard') }}" class="nav-link">Dashboard</a>
+    <a href="{{ url_for('home') }}" class="nav-link">Dashboard</a>
     <a href="{{ url_for('corpus') }}" class="nav-link">Corpus</a>
     <a href="{{ url_for('document') }}" class="nav-link">Document</a>
     <a href="{{ url_for('graph_page') }}" class="nav-link">Graph</a>

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -10,7 +10,7 @@
 <aside class="sidebar" data-collapsed="false">
   <button class="sidebar-toggle btn ghost" aria-label="Toggle sidebar">☰</button>
   <nav>
-    <a href="{{ url_for('dashboard') }}" class="nav-link">Dashboard</a>
+    <a href="{{ url_for('home') }}" class="nav-link">Dashboard</a>
     <a href="{{ url_for('corpus') }}" class="nav-link">Corpus</a>
     <a href="{{ url_for('document') }}" class="nav-link">Document</a>
     <a href="{{ url_for('graph_page') }}" class="nav-link">Graph</a>

--- a/templates/sql.html
+++ b/templates/sql.html
@@ -10,7 +10,7 @@
 <aside class="sidebar" data-collapsed="false">
   <button class="sidebar-toggle btn ghost" aria-label="Toggle sidebar">☰</button>
   <nav>
-    <a href="{{ url_for('dashboard') }}" class="nav-link">Dashboard</a>
+    <a href="{{ url_for('home') }}" class="nav-link">Dashboard</a>
     <a href="{{ url_for('corpus') }}" class="nav-link">Corpus</a>
     <a href="{{ url_for('document') }}" class="nav-link">Document</a>
     <a href="{{ url_for('graph_page') }}" class="nav-link">Graph</a>


### PR DESCRIPTION
## Summary
- Replace outdated `url_for('dashboard')` references with `url_for('home')` in sidebar navigation templates

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6898e4d0c5dc832495a87a2821cb368d