### PR TITLE
Integrate full pipeline interface

### DIFF
--- a/templates/pipelines.html
+++ b/templates/pipelines.html
@@ -28,7 +28,35 @@
   </div>
 </header>
 <main class="page">
-  <div class="card"><h1>Pipelines</h1><p>Runs table placeholder.</p></div>
+  <div class="card">
+    <h1>Run Pipeline</h1>
+    {% if error %}<p style="color:red">{{ error }}</p>{% endif %}
+    <form method="post" enctype="multipart/form-data" style="display:flex;flex-direction:column;gap:.5rem;max-width:400px;">
+      <label>Document <input type="file" name="file" required></label>
+      <label>Model <input type="text" name="model" value="gpt-4o"></label>
+      <button type="submit" class="btn">Run</button>
+    </form>
+  </div>
+  <div class="card">
+    <h2>Available Runs</h2>
+    {% if runs %}
+    <table>
+      <thead><tr><th>Name</th><th>Structure</th><th>NER</th><th>Decision</th></tr></thead>
+      <tbody>
+      {% for r in runs %}
+        <tr>
+          <td>{{ r.name }}</td>
+          <td>{% if r.structure %}<a href="{{ url_for('download_output', filename=r.structure) }}">{{ r.structure }}</a>{% else %}-{% endif %}</td>
+          <td>{% if r.ner %}<a href="{{ url_for('download_ner_output', filename=r.ner) }}">{{ r.ner }}</a>{% else %}-{% endif %}</td>
+          <td>{% if r.decision %}<a href="{{ url_for('download_output', filename=r.decision) }}">{{ r.decision }}</a>{% else %}-{% endif %}</td>
+        </tr>
+      {% endfor %}
+      </tbody>
+    </table>
+    {% else %}
+      <p>No runs found.</p>
+    {% endif %}
+  </div>
 </main>
 </div>
 <div id="palette" class="palette hidden" role="dialog" aria-modal="true">


### PR DESCRIPTION
## Summary
- Add end-to-end pipeline execution endpoint in `app.py` that handles OCR, chunk extraction, post-processing, structured NER, optional decision parsing, and database import, saving results to `output` and `ner_output` directories.
- Expose routes for downloading structured and NER outputs and update document collection to include decision files.
- Replace placeholder pipeline page with a functional interface to run the pipeline and browse generated outputs.

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6898ec6f98a48324906c53ba06761585