### PR TITLE
Fix entity annotation popup disappearing on click

### DIFF
--- a/static/annotations.js
+++ b/static/annotations.js
@@ -132,7 +132,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 editMode = false;
             }
         }
-        if (!actionPopup.contains(ev.target)) {
+        if (!actionPopup.contains(ev.target) && !ev.target.closest('.entity-mark')) {
             actionPopup.style.display = 'none';
         }
         if (!ev.target.closest('.entity-mark') && !ev.target.closest('.entity-handle')) {


### PR DESCRIPTION
## Summary
- Prevent action popup from being hidden when clicking on an entity in the annotation editor so edit/delete buttons appear beneath the selected entity.

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6898f2e94e6883248e6e2ce574238bde