### PR TITLE
fix annotation handle dragging

### DIFF
--- a/static/annotations.js
+++ b/static/annotations.js
@@ -329,6 +329,12 @@ document.addEventListener('DOMContentLoaded', () => {
         };
         handle.addEventListener('mousedown', startDrag);
         handle.addEventListener('pointerdown', startDrag);
+        // Some browsers do not bubble move/up events when pointer capture is used,
+        // so also listen on the handles themselves to ensure dragging works.
+        handle.addEventListener('mousemove', moveHandler);
+        handle.addEventListener('pointermove', moveHandler);
+        handle.addEventListener('mouseup', endDrag);
+        handle.addEventListener('pointerup', endDrag);
     });
 
     const moveHandler = ev => {


### PR DESCRIPTION
## Summary
- ensure entity annotation handles listen for move/up events for reliable dragging

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6898fd15e9208324a1e2fe5fffaf6595