### PR TITLE
Fix draggable annotation handles

### DIFF
--- a/static/annotations.js
+++ b/static/annotations.js
@@ -334,6 +334,8 @@ document.addEventListener('DOMContentLoaded', () => {
             const sel = window.getSelection();
             if (sel) sel.removeAllRanges();
             textDiv.style.userSelect = 'none';
+            textDiv.style.webkitUserSelect = 'none';
+            textDiv.style.MozUserSelect = 'none';
             if (handle.setPointerCapture && ev.pointerId !== undefined) {
                 handle.setPointerCapture(ev.pointerId);
             }
@@ -373,10 +375,19 @@ document.addEventListener('DOMContentLoaded', () => {
     document.addEventListener('mousemove', moveHandler);
     document.addEventListener('pointermove', moveHandler);
 
-    function endDrag() {
+    function endDrag(ev) {
         if (!dragTarget) return;
         dragTarget = null;
         textDiv.style.userSelect = '';
+        textDiv.style.webkitUserSelect = '';
+        textDiv.style.MozUserSelect = '';
+        if (ev && ev.pointerId !== undefined) {
+            [startHandle, endHandle].forEach(h => {
+                if (h.releasePointerCapture) {
+                    try { h.releasePointerCapture(ev.pointerId); } catch (e) {}
+                }
+            });
+        }
         if (wasDragging) {
             saveEntity(document.querySelector('.entity-mark.selected'));
             wasDragging = false;

--- a/static/annotations.js
+++ b/static/annotations.js
@@ -293,8 +293,18 @@ document.addEventListener('DOMContentLoaded', () => {
     function getOffsetFromCoords(x, y) {
         const prevVisStart = startHandle.style.visibility;
         const prevVisEnd = endHandle.style.visibility;
+        const prevUserSelect = textDiv.style.userSelect;
+        const prevWebkitUserSelect = textDiv.style.webkitUserSelect;
+        const prevMozUserSelect = textDiv.style.MozUserSelect;
         startHandle.style.visibility = 'hidden';
         endHandle.style.visibility = 'hidden';
+        // Temporarily enable text selection so caretPositionFromPoint works in all browsers.
+        textDiv.style.userSelect = 'text';
+        textDiv.style.webkitUserSelect = 'text';
+        textDiv.style.MozUserSelect = 'text';
+        const rect = textDiv.getBoundingClientRect();
+        x = Math.max(rect.left, Math.min(x, rect.right - 1));
+        y = Math.max(rect.top, Math.min(y, rect.bottom - 1));
         let range;
         if (document.caretPositionFromPoint) {
             const pos = document.caretPositionFromPoint(x, y);
@@ -307,6 +317,9 @@ document.addEventListener('DOMContentLoaded', () => {
         }
         startHandle.style.visibility = prevVisStart;
         endHandle.style.visibility = prevVisEnd;
+        textDiv.style.userSelect = prevUserSelect;
+        textDiv.style.webkitUserSelect = prevWebkitUserSelect;
+        textDiv.style.MozUserSelect = prevMozUserSelect;
         if (!range) return null;
         const node = range.startContainer;
         const off = range.startOffset;


### PR DESCRIPTION
## Summary
- allow bracket handles to move when editing annotations by temporarily enabling text selection while computing caret positions
- clamp drag coordinates within the text container and restore user-select settings for cross-browser compatibility

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6899010ed9e8832495566c2143d59824