### PR TITLE
Fix load_settings initialization order

### DIFF
--- a/app.py
+++ b/app.py
@@ -53,8 +53,6 @@ except BaseException:  # pragma: no cover - missing dependency
     run_structured_ner = None
 
 app = Flask(__name__)
-load_settings()
-
 # Path to the SQLite database used for querying
 DB_PATH = os.environ.get("DB_PATH", "legislation.db")
 
@@ -105,6 +103,9 @@ def save_settings(data: dict) -> None:
 def get_model() -> str:
     """Return the currently configured GPT model."""
     return load_settings().get("model", "gpt-3.5-turbo-16k")
+
+# Initialise settings and credentials at import time
+load_settings()
 
 # Arabic labels for relation types
 RELATION_LABELS = {


### PR DESCRIPTION
## Summary
- Avoid `NameError` on startup by moving `load_settings` call after its definition

## Testing
- `pytest`
- `python3 app.py` *(fails: ModuleNotFoundError: No module named 'flask')*
- `pip install flask` *(fails: Could not find a version that satisfies the requirement flask; Proxy 403)*

------
https://chatgpt.com/codex/tasks/task_e_68996f7242c08324b5bf16d968e44267