### PR TITLE
Fix Add Entity button in annotation editor

### DIFF
--- a/static/annotations.js
+++ b/static/annotations.js
@@ -186,6 +186,9 @@ document.addEventListener('DOMContentLoaded', () => {
     });
 
     document.addEventListener('click', ev => {
+        if (addMode && textDiv.contains(ev.target)) {
+            return;
+        }
         if (!editPopup.contains(ev.target)) {
             editPopup.style.display = 'none';
             if (!ev.target.closest('.entity-mark') && !ev.target.closest('.entity-handle')) {


### PR DESCRIPTION
## Summary
- prevent global click handler from cancelling entity addition so selection popup stays visible

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6899736182408324a17d940fff13dbb2