### PR TITLE
feat: allow keyboard adjustment of annotation bounds

### DIFF
--- a/static/annotations.js
+++ b/static/annotations.js
@@ -495,6 +495,43 @@ document.addEventListener('DOMContentLoaded', () => {
         });
     });
 
+    // Allow fine-tuning entity boundaries with the keyboard.
+    // Alt+Arrow adjusts the start, Shift+Arrow adjusts the end.
+    document.addEventListener('keydown', ev => {
+        if (!editMode) return;
+        const span = document.querySelector('.entity-mark.selected');
+        if (!span) return;
+        let start = parseInt(span.dataset.start, 10) || 0;
+        let end = parseInt(span.dataset.end, 10) || 0;
+        const maxLen = textDiv.textContent.length;
+        let changed = false;
+        if (ev.altKey) {
+            if (ev.key === 'ArrowLeft') {
+                start = Math.max(0, start - 1);
+                changed = true;
+            } else if (ev.key === 'ArrowRight') {
+                start = Math.min(end, start + 1);
+                changed = true;
+            }
+        } else if (ev.shiftKey) {
+            if (ev.key === 'ArrowLeft') {
+                end = Math.max(start, end - 1);
+                changed = true;
+            } else if (ev.key === 'ArrowRight') {
+                end = Math.min(maxLen, end + 1);
+                changed = true;
+            }
+        }
+        if (changed) {
+            span.dataset.start = start;
+            span.dataset.end = end;
+            setSelectionRange(start, end);
+            positionHandles(span);
+            saveEntity(span);
+            ev.preventDefault();
+        }
+    });
+
     document.querySelectorAll('.entity-mark').forEach(span => {
         span.addEventListener('click', () => {
             document.querySelectorAll('.entity-mark').forEach(s => s.classList.remove('selected'));


### PR DESCRIPTION
## Summary
- enable keyboard-based fine-tuning of entity annotation boundaries via Alt/Shift + arrow keys

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6899757189f48324b2daa899e2ce10fb