### PR TITLE
Fix annotation editor entity offset calculation and ID generation

### DIFF
--- a/annotation_editor.py
+++ b/annotation_editor.py
@@ -7,7 +7,14 @@ except Exception:  # pragma: no cover - allow standalone use
     from ner import parse_marked_text, text_with_markers, fix_entity_offsets  # type: ignore
 
 
-def _next_id(entities: list[dict]) -> str:
+def _next_id(entities: list[dict]) -> int:
+    """Return the next available integer ID for *entities*.
+
+    Existing IDs may be numeric or alphanumeric; any trailing digit
+    sequence is considered when determining the next value.  The returned
+    ID is an integer without any prefix such as ``ENT_``.
+    """
+
     nums: list[int] = []
     for e in entities:
         sid = str(e.get("id", ""))
@@ -18,7 +25,7 @@ def _next_id(entities: list[dict]) -> str:
             except Exception:
                 pass
     n = max(nums) + 1 if nums else 1
-    return f"ENT_{n}"
+    return n
 
 
 def load_file(path: str) -> tuple[str, list[dict]]:

--- a/tests/test_edit_annotations.py
+++ b/tests/test_edit_annotations.py
@@ -94,4 +94,7 @@ def test_add_entity_updates_structure_json(tmp_path, monkeypatch):
     assert resp.status_code == 200
     with open(structure_path, 'r', encoding='utf-8') as f:
         struct = json.load(f)
-    assert struct['text'] == '<القانون, id:ENT_1>'
+    assert struct['text'] == '<القانون, id:1>'
+    with open(ner_path, 'r', encoding='utf-8') as f:
+        ner_saved = json.load(f)
+    assert ner_saved['entities'][0]['id'] == 1


### PR DESCRIPTION
## Summary
- ensure entity offsets only count document text and ignore navigation labels
- use filtered tree walker for accurate selections and handle repositioning
- generate numeric IDs for new annotations instead of `ENT_*` prefixes

## Testing
- `pytest` (14 passed, 3 skipped)


------
https://chatgpt.com/codex/tasks/task_e_689b63dc18e083248ca9e296c60df548