### PR TITLE
Ensure entity edits target selected occurrence

### DIFF
--- a/static/annotations.js
+++ b/static/annotations.js
@@ -529,7 +529,14 @@ document.addEventListener('DOMContentLoaded', () => {
             const tr = btn.closest('tr');
             if (!tr) return;
             document.querySelectorAll('.entity-mark').forEach(s => s.classList.remove('selected'));
-            const span = document.querySelector(`.entity-mark[data-id="${tr.dataset.id}"]`);
+            // Use the span that triggered the edit if available; otherwise fall back
+            // to the first occurrence of this entity ID.
+            let span = null;
+            if (currentSpan && currentSpan.dataset.id === tr.dataset.id) {
+                span = currentSpan;
+            } else {
+                span = document.querySelector(`.entity-mark[data-id="${tr.dataset.id}"]`);
+            }
             if (span) {
                 editMode = true;
                 span.classList.add('selected');


### PR DESCRIPTION
## Summary
- Preserve selected entity span when editing annotations
- Avoid mis-highlighting when multiple mentions share an entity id

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689b7c32693c8324b8563e54403fbe2f