### PR TITLE
Fix annotation popup disappearing during span edits

### DIFF
--- a/static/annotations.js
+++ b/static/annotations.js
@@ -242,7 +242,7 @@ document.addEventListener('DOMContentLoaded', () => {
     });
 
     document.addEventListener('click', ev => {
-        if (addMode && textDiv.contains(ev.target)) {
+        if ((addMode || editMode) && textDiv.contains(ev.target)) {
             return;
         }
         const insideText = textDiv.contains(ev.target);


### PR DESCRIPTION
## Summary
- Prevent the annotation editor's popup from hiding when selecting text
- Keep Save button visible while adjusting entity spans

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689b835b483883249d74fd5094138c14