### PR TITLE
Handle duplicated article numbers from OCR footnotes

### DIFF
--- a/pipeline/extract_chunks.py
+++ b/pipeline/extract_chunks.py
@@ -30,6 +30,7 @@ def run_passes(txt_path: str, model: str) -> dict:
     full_obj = json.loads(raw_full) if isinstance(raw_full, str) else raw_full
     structure_tree = full_obj.get("structure", [])
     gpt.finalize_structure(structure_tree)
+    gpt.fix_duplicate_numbers(structure_tree)
 
     def collect_annexes(nodes: list) -> tuple[list, list]:
         remaining: list = []

--- a/pipeline/gpt_helpers.py
+++ b/pipeline/gpt_helpers.py
@@ -439,6 +439,51 @@ def finalize_structure(tree: list, seen: set | None = None) -> None:
             finalize_structure(node["children"], seen)
 
 
+def fix_duplicate_numbers(tree: list) -> None:
+    """Collapse article numbers polluted by OCR footnote digits.
+
+    OCR systems sometimes glue a superscript footnote marker to the article
+    number.  Depending on whether the marker appears before or after the
+    number, this yields either a repeated digit (``22`` instead of ``2``) or a
+    prefixed digit (``28`` instead of ``8`` or ``110`` instead of ``10``).
+
+    This pass walks sibling lists and normalizes such numbers by comparing
+    them to the expected sequential value.  Legitimate jumps such as ``22``
+    following ``21`` are left untouched.
+    """
+
+    def _walk(nodes: list) -> None:
+        last: dict[str, int] = {}
+        for node in nodes:
+            typ = canonical_type(node.get("type", ""))
+            num = node.get("number")
+            if typ in ARTICLE_TYPES and isinstance(num, str) and num.isdigit():
+                prev = last.get(typ)
+                val = int(num)
+                if prev is not None:
+                    expected = prev + 1
+                    exp_str = str(expected)
+                    if val != expected:
+                        if num.endswith(exp_str):
+                            # e.g. ``17`` after ``6`` -> ``7`` or ``110`` after
+                            # ``9`` -> ``10`` where a footnote digit prefixes
+                            # the real number.
+                            val = expected
+                            node["number"] = exp_str
+                        elif len(num) == len(exp_str) * 2 and num == exp_str * 2:
+                            # e.g. ``22`` after ``1`` -> ``2`` where the
+                            # footnote digit was appended to the number.
+                            val = expected
+                            node["number"] = exp_str
+                    else:
+                        val = expected
+                last[typ] = val
+            if node.get("children"):
+                _walk(node["children"])
+
+    _walk(tree)
+
+
 def break_cycles(nodes: list, active: set[int] | None = None, seen: set[int] | None = None) -> None:
     if active is None:
         active = set()

--- a/tests/test_fix_duplicate_numbers.py
+++ b/tests/test_fix_duplicate_numbers.py
@@ -1,0 +1,70 @@
+import os
+import sys
+import types
+
+# Provide a tiny stub for tiktoken so tests run in environments without the
+# optional dependency.
+tok_stub = types.SimpleNamespace(
+    encoding_for_model=lambda _model: types.SimpleNamespace(
+        encode=lambda s: [], decode=lambda t: ""
+    )
+)
+sys.modules.setdefault("tiktoken", tok_stub)
+
+# Stub for openai as well; only ``api_key`` attribute is accessed during tests.
+openai_stub = types.SimpleNamespace(api_key=None)
+sys.modules.setdefault("openai", openai_stub)
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from pipeline import gpt_helpers as gpt
+
+
+def normalize(structure):
+    gpt.finalize_structure(structure)
+    gpt.fix_duplicate_numbers(structure)
+    return [n.get("number") for n in structure]
+
+
+def test_collapses_footnote_digit():
+    items = [
+        {"type": "فصل", "number": "1", "text": "first"},
+        {"type": "فصل", "number": "22", "text": "second"},
+        {"type": "فصل", "number": "3", "text": "third"},
+    ]
+    assert normalize(items) == ["1", "2", "3"]
+
+
+def test_preserves_legitimate_double_digits():
+    items = [
+        {"type": "فصل", "number": "21"},
+        {"type": "فصل", "number": "22"},
+    ]
+    assert normalize(items) == ["21", "22"]
+
+
+def test_strips_prefixed_footnote_digits():
+    items = [
+        {"type": "فصل", "number": "6"},
+        {"type": "فصل", "number": "17"},
+        {"type": "فصل", "number": "8"},
+    ]
+    assert normalize(items) == ["6", "7", "8"]
+
+
+def test_handles_three_digit_prefix():
+    items = [
+        {"type": "فصل", "number": "9"},
+        {"type": "فصل", "number": "110"},
+        {"type": "فصل", "number": "11"},
+    ]
+    assert normalize(items) == ["9", "10", "11"]
+
+
+def test_keeps_legitimate_high_numbers():
+    items = [
+        {"type": "فصل", "number": "16"},
+        {"type": "فصل", "number": "17"},
+        {"type": "فصل", "number": "18"},
+    ]
+    assert normalize(items) == ["16", "17", "18"]


### PR DESCRIPTION
## Summary
- normalize article numbers when footnote digits are prefixed or appended by OCR
- broaden duplicate-number fix to handle prefixed markers like `17`, `28`, `110`
- extend unit tests for prefixed and three-digit footnote cases

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689b959e399c8324a75d2a6c5af80445