### PR TITLE
Add unified home page with processing options and SQL query bar

### DIFF
--- a/static/ui.js
+++ b/static/ui.js
@@ -38,10 +38,6 @@
   const cmdList = document.getElementById('command-list');
   const commands = [
     {name: 'Home', url: '/'},
-    {name: 'Entities', url: '/entities'},
-    {name: 'Structure', url: '/structure'},
-    {name: 'Decision', url: '/decision'},
-    {name: 'SQL', url: '/query'},
     {name: 'Legislation', url: '/legislation'},
     {name: 'Settings', action: () => drawer.classList.add('open')}
   ];

--- a/templates/base.html
+++ b/templates/base.html
@@ -12,10 +12,6 @@
     <div class="logo">Legal AI Assistant</div>
     <nav>
         <a href="{{ url_for('home') }}">Home</a>
-        <a href="{{ url_for('index') }}">Entities</a>
-        <a href="{{ url_for('extract_structure') }}">Structure</a>
-        <a href="{{ url_for('parse_decision_route') }}">Decision</a>
-        <a href="{{ url_for('run_query') }}">SQL</a>
         <a href="{{ url_for('view_legislation') }}">Moroccan Legislation</a>
         <button id="settings-button" class="icon-button popover" data-popover="Settings">⚙️</button>
     </nav>

--- a/templates/home.html
+++ b/templates/home.html
@@ -1,12 +1,30 @@
 {% extends "base.html" %}
-{% block title %}Legal Assistant{% endblock %}
+{% block title %}Home{% endblock %}
 {% block content %}
-<h1>Legal Processing Portal</h1>
-<ul class="menu">
-    <li><a class="button" href="{{ url_for('index') }}">Extract Entities</a></li>
-    <li><a class="button" href="{{ url_for('extract_structure') }}">Chunk &amp; Build Hierarchy</a></li>
-    <li><a class="button" href="{{ url_for('parse_decision_route') }}">Parse Court Decision</a></li>
-    <li><a class="button" href="{{ url_for('run_query') }}">Run SQL Query</a></li>
-    <li><a class="button" href="{{ url_for('view_legislation') }}">Moroccan Legislation</a></li>
-</ul>
+<h1>Document Processing</h1>
+<form method="post" enctype="multipart/form-data">
+    <input type="hidden" name="action" value="process" />
+    <label>Upload PDF or TXT:
+        <input type="file" name="file" required />
+    </label>
+    <div class="options">
+        <label><input type="checkbox" name="decision_parser" /> Add structured court decision parser</label><br/>
+        <label><input type="checkbox" name="structured_ner" /> Add structured NER extraction</label><br/>
+        <label><input type="checkbox" name="save_db" /> Save processed data to Moroccan Legislation</label>
+    </div>
+    <button type="submit">Upload &amp; Process</button>
+</form>
+{% if saved_file %}
+<p>Processed file saved as {{ saved_file }}. <a class="button" href="{{ url_for('view_legislation', file=saved_file) }}">Open</a></p>
+{% endif %}
+{% if process_error %}<div class="error">{{ process_error }}</div>{% endif %}
+<hr/>
+<form method="post">
+    <input type="hidden" name="action" value="query" />
+    <label>SQL Query:</label><br/>
+    <textarea name="sql" rows="4" cols="80">{{ sql }}</textarea><br/>
+    <button type="submit">Run Query</button>
+</form>
+{% if error %}<div class="error">{{ error }}</div>{% endif %}
+{% if result_html %}{{ result_html|safe }}{% endif %}
 {% endblock %}

--- a/tests/test_home_query.py
+++ b/tests/test_home_query.py
@@ -1,0 +1,21 @@
+import sqlite3
+import pytest
+
+flask = pytest.importorskip('flask')
+
+def test_home_sql_query(tmp_path, monkeypatch):
+    db = tmp_path / 'test.db'
+    con = sqlite3.connect(db)
+    cur = con.cursor()
+    cur.execute('CREATE TABLE t (id INTEGER)')
+    cur.execute('INSERT INTO t (id) VALUES (1)')
+    con.commit()
+    con.close()
+    monkeypatch.setenv('DB_PATH', str(db))
+    import importlib
+    import app as app_mod
+    importlib.reload(app_mod)
+    client = app_mod.app.test_client()
+    resp = client.post('/', data={'action': 'query', 'sql': 'SELECT id FROM t'})
+    text = resp.get_data(as_text=True)
+    assert '1' in text

--- a/tests/test_process_toggles.py
+++ b/tests/test_process_toggles.py
@@ -1,0 +1,68 @@
+import io
+import sys
+import pytest
+
+flask = pytest.importorskip('flask')
+
+
+def test_process_toggles_order(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    called = []
+
+    def mock_convert_to_text(input_path, tmp_dir):
+        out = tmp_path / 'input.txt'
+        out.write_text('data', encoding='utf-8')
+        return str(out)
+
+    def mock_run_passes(txt_path, model):
+        return {'structure': []}
+
+    # no-op hierarchy functions
+    monkeypatch.setattr('app.convert_to_text', mock_convert_to_text)
+    monkeypatch.setattr('app.run_passes', mock_run_passes)
+    monkeypatch.setattr('app.postprocess_structure', lambda x: x)
+    monkeypatch.setattr('app.flatten_articles', lambda x: None)
+    monkeypatch.setattr('app.merge_duplicates', lambda x: x)
+    monkeypatch.setattr('app.remove_duplicate_articles', lambda x: None)
+    monkeypatch.setattr('app.attach_stray_articles', lambda x: None)
+
+    def mock_run_structured_ner(data, model):
+        called.append('ner')
+        return data, {}, 'ner_text', {}
+
+    monkeypatch.setattr('app.run_structured_ner', mock_run_structured_ner)
+
+    class MockDecisionModule:
+        @staticmethod
+        def run_structured_decision_parser(data, model):
+            called.append('decision')
+            return {'ok': True}
+
+    monkeypatch.setitem(sys.modules, 'pipeline.structured_decision_parser', MockDecisionModule)
+
+    import app as app_mod
+    client = app_mod.app.test_client()
+
+    def post(data_dict):
+        file_data = (io.BytesIO(b'text'), 'test.txt')
+        data_dict['file'] = file_data
+        client.post('/', data=data_dict, content_type='multipart/form-data')
+
+    # none toggled
+    post({'action': 'process'})
+    assert called == []
+    called.clear()
+
+    # only ner
+    post({'action': 'process', 'structured_ner': 'on'})
+    assert called == ['ner']
+    called.clear()
+
+    # only decision
+    post({'action': 'process', 'decision_parser': 'on'})
+    assert called == ['decision']
+    called.clear()
+
+    # both - decision before ner
+    post({'action': 'process', 'structured_ner': 'on', 'decision_parser': 'on'})
+    assert called == ['decision', 'ner']


### PR DESCRIPTION
## Summary
- Implement new home endpoint handling file uploads, optional decision parsing/NER, database save and SQL queries.
- Redesign home page with upload controls, processing options and SQL query bar.
- Simplify navigation and command palette to focus on home and Moroccan legislation.
- Ensure structured NER CLI outputs entities and relations to a separate file without modifying the annotated JSON.
- Guarantee decision parser runs before structured NER and is mutually exclusive when toggled.
- Add tests verifying processing toggle order and separate NER output.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689be98b7b008324bdec470580209393