### PR TITLE
Add legal documents page and parser output directory

### DIFF
--- a/pipeline/structured_decision_parser.py
+++ b/pipeline/structured_decision_parser.py
@@ -27,7 +27,7 @@ def main() -> None:
     )
     parser.add_argument("--input", required=True, help="Path to input JSON file")
     parser.add_argument(
-        "--output", help="Optional path for JSON output; defaults to decision_output/"
+        "--output", help="Optional path for JSON output; defaults to legal_output/"
     )
     parser.add_argument("--model", default=DEFAULT_MODEL, help="OpenAI model name")
     args = parser.parse_args()
@@ -40,9 +40,9 @@ def main() -> None:
     if args.output:
         out_path = args.output
     else:
-        os.makedirs("decision_output", exist_ok=True)
+        os.makedirs("legal_output", exist_ok=True)
         base = os.path.splitext(os.path.basename(args.input))[0]
-        out_path = os.path.join("decision_output", f"{base}.json")
+        out_path = os.path.join("legal_output", f"{base}.json")
 
     with open(out_path, "w", encoding="utf-8") as f:
         json.dump(result, f, ensure_ascii=False, indent=2)

--- a/templates/base.html
+++ b/templates/base.html
@@ -13,6 +13,7 @@
     <nav>
         <a href="{{ url_for('home') }}">Home</a>
         <a href="{{ url_for('view_legislation') }}">Moroccan Legislation</a>
+        <a href="{{ url_for('view_legal_documents') }}">Legal Documents</a>
         <button id="settings-button" class="icon-button popover" data-popover="Settings">⚙️</button>
     </nav>
 </header>

--- a/templates/home.html
+++ b/templates/home.html
@@ -17,6 +17,9 @@
 {% if saved_file %}
 <p>Processed file saved as {{ saved_file }}. <a class="button" href="{{ url_for('view_legislation', file=saved_file) }}">Open</a></p>
 {% endif %}
+{% if decision_saved %}
+<p>Decision file saved as {{ decision_saved }}. <a class="button" href="{{ url_for('view_legal_documents', file=decision_saved) }}">Open</a></p>
+{% endif %}
 {% if process_error %}<div class="error">{{ process_error }}</div>{% endif %}
 <hr/>
 <form method="post">

--- a/templates/legal_documents.html
+++ b/templates/legal_documents.html
@@ -1,0 +1,33 @@
+{% extends "base.html" %}
+{% block title %}Legal Documents{% endblock %}
+{% block content %}
+<h1>Legal Documents</h1>
+<section class="card">
+    <input type="text" id="search" placeholder="Search files..." />
+    <ul class="file-list" id="file-list">
+    {% for f in files %}
+        <li><a class="button" href="{{ url_for('view_legal_documents', file=f) }}">{{ f }}</a></li>
+    {% else %}
+        <li>No JSON files found.</li>
+    {% endfor %}
+    </ul>
+</section>
+{% if data %}
+<section class="card">
+    <h2>{{ selected }}</h2>
+    <pre id="json-data">{{ data | tojson(indent=2) }}</pre>
+</section>
+{% endif %}
+{% endblock %}
+{% block scripts %}
+<script>
+const searchInput = document.getElementById('search');
+searchInput && searchInput.addEventListener('input', function() {
+    const query = this.value.toLowerCase();
+    document.querySelectorAll('#file-list li').forEach(li => {
+        const text = li.textContent.toLowerCase();
+        li.style.display = text.includes(query) ? '' : 'none';
+    });
+});
+</script>
+{% endblock %}

--- a/tests/test_view_legal_documents.py
+++ b/tests/test_view_legal_documents.py
@@ -1,0 +1,20 @@
+import json
+import pytest
+
+flask = pytest.importorskip('flask')
+
+
+def test_view_legal_documents_lists_files(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    out = tmp_path / 'legal_output'
+    out.mkdir()
+    (out / 'case.json').write_text(json.dumps({'a': 1}), encoding='utf-8')
+
+    import app as app_mod
+    client = app_mod.app.test_client()
+
+    res = client.get('/legal_documents')
+    assert b'case' in res.data
+
+    res = client.get('/legal_documents?file=case')
+    assert b'"a": 1' in res.data


### PR DESCRIPTION
## Summary
- Save structured decision parser results into `legal_output` by default
- Expose decision outputs via a new Legal Documents page and navigation link
- Include template and test coverage for viewing saved decision files

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689bfe6efd2c832498168180df291ee1