### PR TITLE
Allow choosing output destination for uploads

### DIFF
--- a/app.py
+++ b/app.py
@@ -238,7 +238,7 @@ def home():
     error = None
     sql = ''
     saved_file: str | None = None
-    decision_saved: str | None = None
+    saved_to: str | None = None
     process_error: str | None = None
     if request.method == 'POST':
         action = request.form.get('action')
@@ -310,22 +310,24 @@ def home():
                     os.makedirs('data_txt', exist_ok=True)
                     with open(os.path.join('data_txt', f'{base}.txt'), 'w', encoding='utf-8') as f:
                         f.write(raw_text)
-                    os.makedirs('output', exist_ok=True)
-                    out_path = os.path.join('output', f'{base}.json')
+                    output_type = request.form.get('output_type', 'legislation')
+                    if output_type == 'legal':
+                        os.makedirs('legal_output', exist_ok=True)
+                        out_path = os.path.join('legal_output', f'{base}.json')
+                        data_to_save = result.get('decision') or result
+                    else:
+                        os.makedirs('output', exist_ok=True)
+                        out_path = os.path.join('output', f'{base}.json')
+                        data_to_save = result
                     with open(out_path, 'w', encoding='utf-8') as f:
-                        json.dump(result, f, ensure_ascii=False, indent=2)
+                        json.dump(data_to_save, f, ensure_ascii=False, indent=2)
                     if ner_saved:
                         os.makedirs('ner_output', exist_ok=True)
                         ner_json = os.path.join('ner_output', f'{base}_ner.json')
                         with open(ner_json, 'w', encoding='utf-8') as f:
                             json.dump(ner_saved, f, ensure_ascii=False, indent=2)
-                    if result.get('decision'):
-                        os.makedirs('legal_output', exist_ok=True)
-                        dec_path = os.path.join('legal_output', f'{base}.json')
-                        with open(dec_path, 'w', encoding='utf-8') as df:
-                            json.dump(result['decision'], df, ensure_ascii=False, indent=2)
-                        decision_saved = base
                     saved_file = base
+                    saved_to = output_type
                     if request.form.get('save_db'):
                         try:  # pragma: no cover - optional dependency
                             from import_db import import_json
@@ -344,7 +346,7 @@ def home():
         error=error,
         sql=sql,
         saved_file=saved_file,
-        decision_saved=decision_saved,
+        saved_to=saved_to,
         process_error=process_error,
     )
 

--- a/templates/home.html
+++ b/templates/home.html
@@ -8,6 +8,9 @@
         <input type="file" name="file" required />
     </label>
     <div class="options">
+        <label>Save output to:</label>
+        <label><input type="radio" name="output_type" value="legislation" checked /> Moroccan Legislation</label>
+        <label><input type="radio" name="output_type" value="legal" /> Legal Documents</label><br/>
         <label><input type="checkbox" name="decision_parser" /> Add structured court decision parser</label><br/>
         <label><input type="checkbox" name="structured_ner" /> Add structured NER extraction</label><br/>
         <label><input type="checkbox" name="save_db" /> Save processed data to Moroccan Legislation</label>
@@ -15,10 +18,7 @@
     <button type="submit">Upload &amp; Process</button>
 </form>
 {% if saved_file %}
-<p>Processed file saved as {{ saved_file }}. <a class="button" href="{{ url_for('view_legislation', file=saved_file) }}">Open</a></p>
-{% endif %}
-{% if decision_saved %}
-<p>Decision file saved as {{ decision_saved }}. <a class="button" href="{{ url_for('view_legal_documents', file=decision_saved) }}">Open</a></p>
+<p>Processed file saved as {{ saved_file }}. <a class="button" href="{{ url_for('view_legislation' if saved_to=='legislation' else 'view_legal_documents', file=saved_file) }}">Open</a></p>
 {% endif %}
 {% if process_error %}<div class="error">{{ process_error }}</div>{% endif %}
 <hr/>

--- a/tests/test_save_output_type.py
+++ b/tests/test_save_output_type.py
@@ -1,0 +1,40 @@
+import io
+import json
+import sys
+import pytest
+
+flask = pytest.importorskip('flask')
+
+def test_save_output_type(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+
+    def mock_convert_to_text(input_path, tmp_dir):
+        out = tmp_path / 'input.txt'
+        out.write_text('data', encoding='utf-8')
+        return str(out)
+
+    def mock_run_passes(txt_path, model):
+        return {'structure': [], 'decision': {'case': 1}}
+
+    monkeypatch.setattr('app.convert_to_text', mock_convert_to_text)
+    monkeypatch.setattr('app.run_passes', mock_run_passes)
+    monkeypatch.setattr('app.postprocess_structure', lambda x: x)
+    monkeypatch.setattr('app.flatten_articles', lambda x: None)
+    monkeypatch.setattr('app.merge_duplicates', lambda x: x)
+    monkeypatch.setattr('app.remove_duplicate_articles', lambda x: None)
+    monkeypatch.setattr('app.attach_stray_articles', lambda x: None)
+
+    import app as app_mod
+    client = app_mod.app.test_client()
+
+    def post(data_dict, filename):
+        file_data = (io.BytesIO(b'text'), filename)
+        data_dict['file'] = file_data
+        client.post('/', data=data_dict, content_type='multipart/form-data')
+
+    post({'action': 'process'}, 'leg.txt')
+    assert (tmp_path / 'output' / 'leg.json').exists()
+
+    post({'action': 'process', 'output_type': 'legal'}, 'doc.txt')
+    assert (tmp_path / 'legal_output' / 'doc.json').exists()
+    assert not (tmp_path / 'output' / 'doc.json').exists()


### PR DESCRIPTION
## Summary
- Add ability to select whether processed uploads are saved under Moroccan legislation or legal documents
- Expose destination choice in UI and persist it on the backend
- Test saving to correct folder based on user selection

## Testing
- `pytest -q` *(fails: flask dependency unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_689c00c3cb74832491c1486997ff3e0d