### PR TITLE
Remove redundant Moroccan Legislation save option

### DIFF
--- a/app.py
+++ b/app.py
@@ -328,12 +328,6 @@ def home():
                             json.dump(ner_saved, f, ensure_ascii=False, indent=2)
                     saved_file = base
                     saved_to = output_type
-                    if request.form.get('save_db'):
-                        try:  # pragma: no cover - optional dependency
-                            from import_db import import_json
-                            import_json(DB_PATH)
-                        except Exception as exc:
-                            process_error = str(exc)
                 except Exception as exc:  # pragma: no cover - show error
                     process_error = str(exc)
                 finally:

--- a/templates/home.html
+++ b/templates/home.html
@@ -13,7 +13,6 @@
         <label><input type="radio" name="output_type" value="legal" /> Legal Documents</label><br/>
         <label><input type="checkbox" name="decision_parser" /> Add structured court decision parser</label><br/>
         <label><input type="checkbox" name="structured_ner" /> Add structured NER extraction</label><br/>
-        <label><input type="checkbox" name="save_db" /> Save processed data to Moroccan Legislation</label>
     </div>
     <button type="submit">Upload &amp; Process</button>
 </form>


### PR DESCRIPTION
## Summary
- Remove checkbox for saving processed data to Moroccan Legislation from home page
- Drop associated backend `save_db` logic

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689c06be86048324905aacebafe03288