### PR TITLE
Display text and entities for legal documents

### DIFF
--- a/app.py
+++ b/app.py
@@ -769,14 +769,18 @@ def view_legal_documents():
     name = request.args.get('file')
     data = None
     entities = None
+    raw_text = ''
+    ner_html = None
     doc = docs.get(name)
     if doc:
         with open(doc, 'r', encoding='utf-8') as f:
             data = json.load(f)
+        raw_text = data.get('text', '')
         ner_path = os.path.join('ner_output', f'{name}_ner.json')
         if os.path.exists(ner_path):
             with open(ner_path, 'r', encoding='utf-8') as nf:
                 ner_data = json.load(nf)
+            ner_html = render_ner_html(raw_text, ner_data)
             entities = ner_data.get('entities', [])
             relations = ner_data.get('relations', [])
             ent_map = {str(e.get('id')): e for e in entities}
@@ -800,6 +804,8 @@ def view_legal_documents():
         selected=name,
         data=data,
         entities=entities,
+        raw_text=raw_text,
+        ner_html=ner_html,
         settings=load_settings(),
     )
 

--- a/templates/legal_documents.html
+++ b/templates/legal_documents.html
@@ -17,6 +17,12 @@
     <h2>{{ selected }}</h2>
     <div id="json-tree" class="json-tree"></div>
 </section>
+{% if raw_text %}
+<section class="card">
+    <h2>Text</h2>
+    <div id="text-display" dir="rtl">{{ ner_html|safe if ner_html else raw_text|e }}</div>
+</section>
+{% endif %}
 <section class="card">
     <a class="button" href="{{ url_for('edit_legislation', file=selected) }}">Edit annotations</a>
 </section>

--- a/tests/test_view_legal_documents.py
+++ b/tests/test_view_legal_documents.py
@@ -7,8 +7,19 @@ flask = pytest.importorskip('flask')
 def test_view_legal_documents_lists_files(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
     out = tmp_path / 'legal_output'
+    ner_dir = tmp_path / 'ner_output'
     out.mkdir()
-    (out / 'case.json').write_text(json.dumps({'a': 1}), encoding='utf-8')
+    ner_dir.mkdir()
+    (out / 'case.json').write_text(
+        json.dumps({'structure': [], 'text': 'hello world'}), encoding='utf-8'
+    )
+    ner_data = {
+        'entities': [
+            {'id': 1, 'text': 'hello', 'start_char': 0, 'end_char': 5, 'type': 'LAW'},
+        ],
+        'relations': [],
+    }
+    (ner_dir / 'case_ner.json').write_text(json.dumps(ner_data), encoding='utf-8')
 
     import app as app_mod
     client = app_mod.app.test_client()
@@ -20,4 +31,5 @@ def test_view_legal_documents_lists_files(tmp_path, monkeypatch):
     body = res.get_data(as_text=True)
     assert 'json-tree' in body
     assert 'Edit annotations' in body
-    assert '"a":1' in body
+    assert 'hello world' in body
+    assert 'ent-1' in body


### PR DESCRIPTION
## Summary
- Show raw text and highlighted entities when viewing legal documents
- Render NER markup in the template similar to Moroccan legislation viewer
- Add test coverage for legal documents text and entity display

## Testing
- `pytest`
- `pytest tests/test_view_legal_documents.py -vv` *(fails: skipped - missing dependency)*

------
https://chatgpt.com/codex/tasks/task_e_689c09bb2070832487cb88c9f4d14e06