### PR TITLE
Add button to edit decisions in legislation and legal documents

### DIFF
--- a/templates/edit_annotations.html
+++ b/templates/edit_annotations.html
@@ -30,6 +30,32 @@
     </tbody>
 </table>
 </div>
+{% if data and 'facts' in data %}
+<div class="card" style="margin-top:1em;">
+  <h2>Decision Sections</h2>
+  {% for section in ['facts', 'arguments', 'legal_reasons', 'decision'] %}
+  <h3>{{ section.replace('_', ' ').title() }}</h3>
+  <ul>
+    {% for item in data.get(section, []) %}
+    <li>{{ item }}
+      <form method="post" class="inline-form">
+        <input type="hidden" name="action" value="delete_struct" />
+        <input type="hidden" name="category" value="{{ section }}" />
+        <input type="hidden" name="index" value="{{ loop.index0 }}" />
+        <button type="submit" class="button small">Delete</button>
+      </form>
+    </li>
+    {% endfor %}
+  </ul>
+  <form method="post" class="inline-form">
+    <input type="hidden" name="action" value="add_struct" />
+    <input type="hidden" name="category" value="{{ section }}" />
+    <input type="text" name="text" />
+    <button type="submit" class="button small">Add</button>
+  </form>
+  {% endfor %}
+</div>
+{% endif %}
 {% endblock %}
 {% block scripts %}
 <script>

--- a/templates/legal_documents.html
+++ b/templates/legal_documents.html
@@ -25,6 +25,7 @@
 {% endif %}
 <section class="card">
     <a class="button" href="{{ url_for('edit_legislation', file=selected) }}">Edit annotations</a>
+    <a class="button" href="{{ url_for('edit_decision', file=selected) }}">Edit decisions</a>
 </section>
 <div id="popup" style="display:none;position:fixed;top:10%;left:10%;width:80%;max-height:80%;overflow:auto;background:white;border:1px solid #888;padding:10px;z-index:1000;">
     <button id="popup-close" style="float:left;">X</button>

--- a/templates/legislation.html
+++ b/templates/legislation.html
@@ -19,6 +19,7 @@
 </section>
 <section class="card">
     <a class="button" href="{{ url_for('edit_legislation', file=selected) }}">Edit annotations</a>
+    <a class="button" href="{{ url_for('edit_decision', file=selected) }}">Edit decisions</a>
 </section>
 <div id="popup" style="display:none;position:fixed;top:10%;left:10%;width:80%;max-height:80%;overflow:auto;background:white;border:1px solid #888;padding:10px;z-index:1000;">
     <button id="popup-close" style="float:left;">X</button>

--- a/tests/test_edit_decision_sections.py
+++ b/tests/test_edit_decision_sections.py
@@ -1,0 +1,52 @@
+import json
+import pytest
+
+flask = pytest.importorskip('flask')
+from app import app
+
+
+def _setup_dirs(tmp_path):
+    legal_dir = tmp_path / 'legal_output'
+    ner_dir = tmp_path / 'ner_output'
+    txt_dir = tmp_path / 'data_txt'
+    legal_dir.mkdir()
+    ner_dir.mkdir()
+    txt_dir.mkdir()
+    with open(legal_dir / 'test.json', 'w', encoding='utf-8') as f:
+        json.dump({
+            'facts': [],
+            'arguments': [],
+            'legal_reasons': [],
+            'decision': []
+        }, f)
+    with open(ner_dir / 'test_ner.json', 'w', encoding='utf-8') as f:
+        json.dump({'entities': [], 'relations': []}, f)
+    with open(txt_dir / 'test.txt', 'w', encoding='utf-8') as f:
+        f.write('abc')
+    return legal_dir
+
+
+def test_add_delete_sections(tmp_path, monkeypatch):
+    legal_dir = _setup_dirs(tmp_path)
+    monkeypatch.chdir(tmp_path)
+    client = app.test_client()
+
+    resp = client.post('/decision/edit?file=test', data={
+        'action': 'add_struct',
+        'category': 'facts',
+        'text': 'fact1'
+    })
+    assert resp.status_code == 200
+    with open(legal_dir / 'test.json', 'r', encoding='utf-8') as f:
+        data = json.load(f)
+    assert data['facts'] == ['fact1']
+
+    resp = client.post('/decision/edit?file=test', data={
+        'action': 'delete_struct',
+        'category': 'facts',
+        'index': '0'
+    })
+    assert resp.status_code == 200
+    with open(legal_dir / 'test.json', 'r', encoding='utf-8') as f:
+        data = json.load(f)
+    assert data['facts'] == []


### PR DESCRIPTION
## Summary
- Allow adding or removing `facts`, `arguments`, `legal_reasons`, and `decision` sections when editing decisions
- Expose form controls in the annotation editor for managing decision sections
- Test editing of decision sections via `/decision/edit`

## Testing
- `pytest`
- `pip install flask` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689c0eb193948324ab3bb76d4951d084