### PR TITLE
Handle invalid unicode escapes in model responses

### DIFF
--- a/decision_parser.py
+++ b/decision_parser.py
@@ -1,5 +1,6 @@
 import os
 import json
+import re
 import argparse
 
 try:
@@ -48,7 +49,13 @@ def call_openai(prompt: str, model: str = DEFAULT_MODEL) -> dict:
         response_format={"type": "json_object"},
     )
     content = resp.choices[0].message.content
-    return json.loads(content)
+    try:
+        return json.loads(content)
+    except json.JSONDecodeError as exc:
+        if "Invalid \\u" in str(exc):
+            fixed = re.sub(r"\\u(?![0-9a-fA-F]{4})", r"\\\\u", content)
+            return json.loads(fixed)
+        raise
 
 
 def process_file(path: str, model: str = DEFAULT_MODEL) -> dict:

--- a/ner.py
+++ b/ner.py
@@ -585,7 +585,13 @@ def call_openai(prompt: str, model: str = DEFAULT_MODEL) -> Dict[str, Any]:
         response_format={"type": "json_object"},
     )
     content = resp.choices[0].message.content
-    return json.loads(content)
+    try:
+        return json.loads(content)
+    except json.JSONDecodeError as exc:
+        if "Invalid \\u" in str(exc):
+            fixed = re.sub(r"\\u(?![0-9a-fA-F]{4})", r"\\\\u", content)
+            return json.loads(fixed)
+        raise
 
 
 def _chunk_text(text: str, model: str, max_tokens: int) -> list[tuple[str, int]]:


### PR DESCRIPTION
## Summary
- Avoid JSON decoding errors when model output contains malformed `\u` escapes by sanitizing responses before parsing.
- Apply the same fix for decision parsing to improve robustness.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689c19ebf90483249d98845f4a8363b9