### PR TITLE
Handle malformed JSON from NER output

### DIFF
--- a/ner.py
+++ b/ner.py
@@ -591,7 +591,13 @@ def call_openai(prompt: str, model: str = DEFAULT_MODEL) -> Dict[str, Any]:
         if "Invalid \\u" in str(exc):
             fixed = re.sub(r"\\u(?![0-9a-fA-F]{4})", r"\\\\u", content)
             return json.loads(fixed)
-        raise
+        match = re.search(r"\{.*\}", content, re.DOTALL)
+        if match:
+            try:
+                return json.loads(match.group(0))
+            except json.JSONDecodeError:
+                pass
+        raise RuntimeError(f"Model returned invalid JSON: {content}") from exc
 
 
 def _chunk_text(text: str, model: str, max_tokens: int) -> list[tuple[str, int]]:

--- a/pipeline/structured_ner.py
+++ b/pipeline/structured_ner.py
@@ -5,6 +5,9 @@ from typing import Any, Dict, List, Tuple
 
 try:  # Prefer relative import when available
     from ..ner import extract_entities, postprocess_result, json_to_text
+    # ``extract_entities`` ultimately calls ``ner.call_openai`` which now
+    # includes defensive JSON recovery. Importing from ``ner`` here ensures
+    # structured NER benefits from that logic without duplicating it.
 except Exception:  # Allow running as a script
     from ner import extract_entities, postprocess_result, json_to_text  # type: ignore
 

--- a/tests/test_call_openai_recovery.py
+++ b/tests/test_call_openai_recovery.py
@@ -1,0 +1,13 @@
+import sys, os
+sys.path.insert(0, os.getcwd())
+import ner
+from types import SimpleNamespace
+
+
+def test_call_openai_extracts_json(monkeypatch):
+    fake_content = "noise before {\"entities\": []} noise after"
+    fake_resp = SimpleNamespace(choices=[SimpleNamespace(message=SimpleNamespace(content=fake_content))])
+    openai_mock = SimpleNamespace(chat=SimpleNamespace(completions=SimpleNamespace(create=lambda **kwargs: fake_resp)))
+    monkeypatch.setattr(ner, "openai", openai_mock)
+    result = ner.call_openai("prompt", model="gpt-4o")
+    assert result == {"entities": []}


### PR DESCRIPTION
## Summary
- Add defensive parsing in `call_openai` to recover JSON even when the model returns extra text or invalid unicode
- Raise a clearer runtime error when JSON can't be recovered
- Add regression test ensuring noisy model responses are handled
- Document in `structured_ner` that it leverages `ner.call_openai`'s robust parsing

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689c1df19728832485d205a960c6d900