### PR TITLE
Separate NER output and streamline legal document view

### DIFF
--- a/app.py
+++ b/app.py
@@ -357,14 +357,10 @@ def home():
                         }
                         if request.form.get('decision_parser') and result.get('decision'):
                             data_to_save['decision'] = result['decision']
-                        if request.form.get('structured_ner') and ner_saved:
-                            data_to_save['ner'] = ner_saved
                     else:
                         os.makedirs('output', exist_ok=True)
                         out_path = os.path.join('output', f'{base}.json')
                         data_to_save = result
-                        if request.form.get('structured_ner') and ner_saved:
-                            data_to_save['ner'] = ner_saved
                     with open(out_path, 'w', encoding='utf-8') as f:
                         json.dump(data_to_save, f, ensure_ascii=False, indent=2)
                     if request.form.get('structured_ner') and ner_saved:
@@ -783,19 +779,18 @@ def view_legal_documents():
     files = sorted(docs.keys())
     name = request.args.get('file')
     data = None
+    decision = None
     entities = None
-    raw_text = ''
-    ner_html = None
     doc = docs.get(name)
     if doc:
         with open(doc, 'r', encoding='utf-8') as f:
-            data = json.load(f)
-        raw_text = data.get('text', '')
+            loaded = json.load(f)
+        data = loaded.get('structure')
+        decision = loaded.get('decision')
         ner_path = os.path.join('ner_output', f'{name}_ner.json')
         if os.path.exists(ner_path):
             with open(ner_path, 'r', encoding='utf-8') as nf:
                 ner_data = json.load(nf)
-            ner_html = render_ner_html(raw_text, ner_data)
             entities = ner_data.get('entities', [])
             relations = ner_data.get('relations', [])
             ent_map = {str(e.get('id')): e for e in entities}
@@ -818,9 +813,8 @@ def view_legal_documents():
         files=files,
         selected=name,
         data=data,
+        decision=decision,
         entities=entities,
-        raw_text=raw_text,
-        ner_html=ner_html,
         settings=load_settings(),
     )
 

--- a/static/style.css
+++ b/static/style.css
@@ -104,6 +104,8 @@ pre { background: var(--color-surface); padding:10px; border-radius:var(--radius
 
 .entity-mark { background-color: #ffff00; }
 .entity-mark.selected { background-color: orange; }
+.entity-link { background-color: #ffff00; color: inherit; text-decoration: underline; }
+.entity-link.selected { background-color: orange; }
 .entity-handle { position:absolute; z-index:100; font-weight:bold; cursor:ew-resize; user-select:none; color:red; touch-action:none; }
 
 .annotation-popup { position:absolute; z-index:200; background:var(--color-surface); border:1px solid var(--color-border); padding:4px; border-radius:var(--radius); box-shadow: var(--shadow); }

--- a/templates/legal_documents.html
+++ b/templates/legal_documents.html
@@ -17,10 +17,17 @@
     <h2>{{ selected }}</h2>
     <div id="json-tree" class="json-tree"></div>
 </section>
-{% if raw_text %}
+{% if decision %}
 <section class="card">
-    <h2>Text</h2>
-    <div id="text-display" dir="rtl">{{ ner_html|safe if ner_html else raw_text|e }}</div>
+    <h2>Decision</h2>
+    {% for key, items in decision.items() %}
+        <h3>{{ key.replace('_', ' ') }}</h3>
+        <ul>
+        {% for item in items %}
+            <li>{{ item }}</li>
+        {% endfor %}
+        </ul>
+    {% endfor %}
 </section>
 {% endif %}
 <section class="card">

--- a/tests/test_save_output_type.py
+++ b/tests/test_save_output_type.py
@@ -82,7 +82,7 @@ def test_save_output_type(tmp_path, monkeypatch):
     assert saved['text'] == 'data'
     assert saved['structure'] == [{'text': 'data'}]
     assert saved['decision'] == {'case': 1}
-    assert saved['ner'] == {'entities': []}
+    assert 'ner' not in saved
     assert (tmp_path / 'ner_output' / 'doc_ner.json').exists()
     assert not (tmp_path / 'output' / 'doc.json').exists()
     assert calls['run_passes'] == 1

--- a/tests/test_view_legal_documents.py
+++ b/tests/test_view_legal_documents.py
@@ -11,7 +11,8 @@ def test_view_legal_documents_lists_files(tmp_path, monkeypatch):
     out.mkdir()
     ner_dir.mkdir()
     (out / 'case.json').write_text(
-        json.dumps({'structure': [], 'text': 'hello world'}), encoding='utf-8'
+        json.dumps({'structure': [{'text': '<hello, id:1> world'}], 'text': 'hello world'}),
+        encoding='utf-8',
     )
     ner_data = {
         'entities': [
@@ -31,5 +32,5 @@ def test_view_legal_documents_lists_files(tmp_path, monkeypatch):
     body = res.get_data(as_text=True)
     assert 'json-tree' in body
     assert 'Edit annotations' in body
-    assert 'hello world' in body
-    assert 'ent-1' in body
+    assert 'Text</h2>' not in body
+    assert 'id:1' in body


### PR DESCRIPTION
## Summary
- Avoid embedding NER results in saved legal or legislation JSON; save NER to dedicated files only
- Simplify legal document viewer by dropping raw text, highlighting entities in structure, and showing parsed decisions
- Style entity links and adjust tests for new behaviour

## Testing
- `pytest` *(fails: missing dependency Flask; attempted `pip install flask` but no matching distribution due to proxy)*

------
https://chatgpt.com/codex/tasks/task_e_689cec079b148324928e9f13dbc7681e