### PR TITLE
Support editing decisions stored in dedicated directory

### DIFF
--- a/app.py
+++ b/app.py
@@ -636,6 +636,10 @@ def _collect_legal_documents() -> dict[str, str]:
 def _load_annotation(name: str) -> tuple[str, list[dict], list[dict], str, str]:
     """Load raw text and NER data for *name* along with file paths."""
     txt_path = os.path.join('data_txt', f'{name}.txt')
+    if not os.path.exists(txt_path):
+        alt = os.path.join('court_decision_txt', f'{name}.txt')
+        if os.path.exists(alt):
+            txt_path = alt
     ner_path = os.path.join('ner_output', f'{name}_ner.json')
     text = ''
     if os.path.exists(txt_path):

--- a/tests/test_edit_decision_sections.py
+++ b/tests/test_edit_decision_sections.py
@@ -5,10 +5,10 @@ flask = pytest.importorskip('flask')
 from app import app
 
 
-def _setup_dirs(tmp_path):
+def _setup_dirs(tmp_path, text_dir='data_txt'):
     legal_dir = tmp_path / 'legal_output'
     ner_dir = tmp_path / 'ner_output'
-    txt_dir = tmp_path / 'data_txt'
+    txt_dir = tmp_path / text_dir
     legal_dir.mkdir()
     ner_dir.mkdir()
     txt_dir.mkdir()
@@ -50,3 +50,13 @@ def test_add_delete_sections(tmp_path, monkeypatch):
     with open(legal_dir / 'test.json', 'r', encoding='utf-8') as f:
         data = json.load(f)
     assert data['facts'] == []
+
+
+def test_edit_decision_reads_court_decision_txt(tmp_path, monkeypatch):
+    _setup_dirs(tmp_path, text_dir='court_decision_txt')
+    monkeypatch.chdir(tmp_path)
+    client = app.test_client()
+
+    resp = client.get('/decision/edit?file=test')
+    assert resp.status_code == 200
+    assert b'abc' in resp.data


### PR DESCRIPTION
## Summary
- allow annotation loader to fall back to `court_decision_txt` when `data_txt` is missing
- verify decision editor loads text from `court_decision_txt`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689cf0913e308324aa500b4b3072073b