### PR TITLE
Show relation details in entity popups

### DIFF
--- a/templates/legal_documents.html
+++ b/templates/legal_documents.html
@@ -94,7 +94,15 @@ function formatText(value) {
         const attrs = [`class=\"entity-link\"`, `href=\"#\"`];
         const target = articleTargets[id];
         if (target) attrs.push(`data-target=\"${target}\"`);
-        if (ent.text) attrs.push(`data-popup=\"${escapeHtml(ent.text)}\"`);
+        const popup = [];
+        if (ent.text) popup.push(`<p>${escapeHtml(ent.text)}</p>`);
+        ['references', 'relations'].forEach(key => {
+            const items = ent[key];
+            if (items && items.length) {
+                popup.push('<ul>' + items.map(r => `<li>${escapeHtml(r)}</li>`).join('') + '</ul>');
+            }
+        });
+        if (popup.length) attrs.push(`data-popup=\"${popup.join('')}\"`);
         return `<a ${attrs.join(' ')}>${escapeHtml(txt)}</a>`;
     });
 }

--- a/templates/legislation.html
+++ b/templates/legislation.html
@@ -81,7 +81,15 @@ function formatText(value) {
         const attrs = [`class=\"entity-link\"`, `href=\"#\"`];
         const target = articleTargets[id];
         if (target) attrs.push(`data-target=\"${target}\"`);
-        if (ent.text) attrs.push(`data-popup=\"${escapeHtml(ent.text)}\"`);
+        const popup = [];
+        if (ent.text) popup.push(`<p>${escapeHtml(ent.text)}</p>`);
+        ['references', 'relations'].forEach(key => {
+            const items = ent[key];
+            if (items && items.length) {
+                popup.push('<ul>' + items.map(r => `<li>${escapeHtml(r)}</li>`).join('') + '</ul>');
+            }
+        });
+        if (popup.length) attrs.push(`data-popup=\"${popup.join('')}\"`);
         return `<a ${attrs.join(' ')}>${escapeHtml(txt)}</a>`;
     });
 }

--- a/tests/test_view_legislation_entities.py
+++ b/tests/test_view_legislation_entities.py
@@ -68,3 +68,33 @@ def test_entity_links_only_when_related(tmp_path, monkeypatch):
     assert 'href="#entity-1"' in body
     assert 'href="#entity-2"' in body
     assert 'href="#entity-3"' not in body
+
+
+def test_entity_popup_includes_relations(tmp_path, monkeypatch):
+    out_dir = tmp_path / 'output'
+    ner_dir = tmp_path / 'ner_output'
+    out_dir.mkdir()
+    ner_dir.mkdir()
+
+    structure_path = out_dir / 'test.json'
+    with open(structure_path, 'w', encoding='utf-8') as f:
+        json.dump({'text': '<القانون 1, id:1> <الفصل 2, id:2>'}, f, ensure_ascii=False)
+
+    ner_data = {
+        'entities': [
+            {'id': 1, 'text': 'القانون 1', 'type': 'LAW'},
+            {'id': 2, 'text': 'الفصل 2', 'type': 'ARTICLE'},
+        ],
+        'relations': [
+            {'source_id': 1, 'target_id': 2, 'type': 'refers_to'},
+        ],
+    }
+    ner_path = ner_dir / 'test_ner.json'
+    with open(ner_path, 'w', encoding='utf-8') as f:
+        json.dump(ner_data, f, ensure_ascii=False)
+
+    monkeypatch.chdir(tmp_path)
+    client = app.test_client()
+    resp = client.get('/legislation?file=test')
+    body = resp.get_data(as_text=True)
+    assert '&lt;li&gt;القانون 1 يشير إلى الفصل 2&lt;/li&gt;' in body


### PR DESCRIPTION
## Summary
- Display related entities and references in popups on legislation and legal document views
- Test that entity popups contain relation information

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689cfa2ee4c4832490558a54ba340026