### PR TITLE
Highlight entities in legal document decisions

### DIFF
--- a/templates/legal_documents.html
+++ b/templates/legal_documents.html
@@ -18,13 +18,13 @@
     <div id="json-tree" class="json-tree"></div>
 </section>
 {% if decision %}
-<section class="card">
+<section class="card" id="decision-section">
     <h2>Decision</h2>
     {% for key, items in decision.items() %}
         <h3>{{ key.replace('_', ' ') }}</h3>
         <ul>
         {% for item in items %}
-            <li>{{ item }}</li>
+            <li class="decision-item">{{ item }}</li>
         {% endfor %}
         </ul>
     {% endfor %}
@@ -219,6 +219,11 @@ document.querySelectorAll('.entity-link').forEach(link => {
 document.getElementById('popup-close').addEventListener('click', () => {
     document.getElementById('popup').style.display = 'none';
 });
+{% if decision %}
+document.querySelectorAll('.decision-item').forEach(li => {
+    li.innerHTML = formatText(li.textContent);
+});
+{% endif %}
 {% endif %}
 </script>
 {% endblock %}

--- a/tests/test_view_legal_documents.py
+++ b/tests/test_view_legal_documents.py
@@ -33,4 +33,5 @@ def test_view_legal_documents_lists_files(tmp_path, monkeypatch):
     assert 'json-tree' in body
     assert 'Edit annotations' in body
     assert 'Text</h2>' not in body
-    assert 'id:1' in body
+    assert 'id:1' not in body
+    assert 'class="entity-link"' in body


### PR DESCRIPTION
## Summary
- highlight entities within decision sections of legal document view without exposing raw markers
- update tests to reflect new entity highlighting behavior

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689cfbd014e0832490f3acb2a5d6fdb6