### PR TITLE
Highlight decision entities in views and editor

### DIFF
--- a/templates/edit_annotations.html
+++ b/templates/edit_annotations.html
@@ -37,7 +37,8 @@
   <h3>{{ section.replace('_', ' ').title() }}</h3>
   <ul>
     {% for item in data.get(section, []) %}
-    <li>{{ item }}
+    <li>
+      <span class="decision-text">{{ item }}</span>
       <form method="post" class="inline-form">
         <input type="hidden" name="action" value="delete_struct" />
         <input type="hidden" name="category" value="{{ section }}" />
@@ -142,6 +143,9 @@ function render(container, obj) {
 if (data) {
     render(document.getElementById('json-tree'), data);
 }
+document.querySelectorAll('.decision-text').forEach(span => {
+    span.innerHTML = formatText(span.textContent);
+});
 </script>
 <script src="{{ url_for('static', filename='annotations.js') }}"></script>
 {% endblock %}

--- a/templates/legislation.html
+++ b/templates/legislation.html
@@ -17,6 +17,19 @@
     <h2>{{ selected }}</h2>
     <div id="json-tree" class="json-tree"></div>
 </section>
+{% if decision %}
+<section class="card" id="decision-section">
+    <h2>Decision</h2>
+    {% for key, items in decision.items() %}
+        <h3>{{ key.replace('_', ' ') }}</h3>
+        <ul>
+        {% for item in items %}
+            <li class="decision-item">{{ item }}</li>
+        {% endfor %}
+        </ul>
+    {% endfor %}
+</section>
+{% endif %}
 <section class="card">
     <a class="button" href="{{ url_for('edit_legislation', file=selected) }}">Edit annotations</a>
     <a class="button" href="{{ url_for('edit_decision', file=selected) }}">Edit decisions</a>
@@ -206,6 +219,11 @@ document.querySelectorAll('.entity-link').forEach(link => {
 document.getElementById('popup-close').addEventListener('click', () => {
     document.getElementById('popup').style.display = 'none';
 });
+{% if decision %}
+document.querySelectorAll('.decision-item').forEach(li => {
+    li.innerHTML = formatText(li.textContent);
+});
+{% endif %}
 {% endif %}
 </script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- expose embedded decision sections in `view_legislation` and render them separately
- highlight entity references inside decision text on both main and edit pages

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689cfda83f0c8324a3efb4fd04b05262