### PR TITLE
Display article text for internal references

### DIFF
--- a/templates/legal_documents.html
+++ b/templates/legal_documents.html
@@ -96,12 +96,16 @@ function formatText(value) {
         if (target) attrs.push(`data-target=\"${target}\"`);
         const popup = [];
         if (ent.text) popup.push(`<p>${escapeHtml(ent.text)}</p>`);
-        ['references', 'relations'].forEach(key => {
-            const items = ent[key];
-            if (items && items.length) {
-                popup.push('<ul>' + items.map(r => `<li>${escapeHtml(r)}</li>`).join('') + '</ul>');
-            }
-        });
+        if (ent.articles && ent.articles.length) {
+            popup.push('<ul>' + ent.articles.map(r => `<li>${escapeHtml(r)}</li>`).join('') + '</ul>');
+        } else {
+            ['references', 'relations'].forEach(key => {
+                const items = ent[key];
+                if (items && items.length) {
+                    popup.push('<ul>' + items.map(r => `<li>${escapeHtml(r)}</li>`).join('') + '</ul>');
+                }
+            });
+        }
         if (popup.length) attrs.push(`data-popup=\"${popup.join('')}\"`);
         return `<a ${attrs.join(' ')}>${escapeHtml(txt)}</a>`;
     });

--- a/templates/legislation.html
+++ b/templates/legislation.html
@@ -96,12 +96,16 @@ function formatText(value) {
         if (target) attrs.push(`data-target=\"${target}\"`);
         const popup = [];
         if (ent.text) popup.push(`<p>${escapeHtml(ent.text)}</p>`);
-        ['references', 'relations'].forEach(key => {
-            const items = ent[key];
-            if (items && items.length) {
-                popup.push('<ul>' + items.map(r => `<li>${escapeHtml(r)}</li>`).join('') + '</ul>');
-            }
-        });
+        if (ent.articles && ent.articles.length) {
+            popup.push('<ul>' + ent.articles.map(r => `<li>${escapeHtml(r)}</li>`).join('') + '</ul>');
+        } else {
+            ['references', 'relations'].forEach(key => {
+                const items = ent[key];
+                if (items && items.length) {
+                    popup.push('<ul>' + items.map(r => `<li>${escapeHtml(r)}</li>`).join('') + '</ul>');
+                }
+            });
+        }
         if (popup.length) attrs.push(`data-popup=\"${popup.join('')}\"`);
         return `<a ${attrs.join(' ')}>${escapeHtml(txt)}</a>`;
     });


### PR DESCRIPTION
## Summary
- collect article text from structured legislation and attach it to internal reference entities
- prefer article content over relation messages in legislation and legal documents popups
- add regression test for internal references showing article text

## Testing
- `pip install flask -q` *(fails: Could not find a version that satisfies the requirement flask)*
- `pytest tests/test_view_legislation_entities.py -q` *(skipped: Flask is required)*

------
https://chatgpt.com/codex/tasks/task_e_689d0dd152448324b7f47fb66f9efdfb