### PR TITLE
Fix article popup highlighting for entity references

### DIFF
--- a/highlight.py
+++ b/highlight.py
@@ -176,6 +176,7 @@ def highlight_text(
             if art is None:
                 art = article_texts.get(f"ID_{ent.get('id')}")
             if art:
+                art = re.sub(r"<([^,<>]+), id:[^>]+>", r"<mark>\1</mark>", art)
                 art = art.replace("\n", "<br/>")
                 art_data = f' data-article="{html.escape(art)}"'
 


### PR DESCRIPTION
## Summary
- render article popup content with highlighted entity references

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689d0ffaa87083249ce560654276bf1d