### PR TITLE
Initialize text variable for legal document view

### DIFF
--- a/app.py
+++ b/app.py
@@ -848,6 +848,7 @@ def view_legal_documents():
     data = None
     decision = None
     entities = None
+    text = None
     doc = docs.get(name)
     if doc:
         with open(doc, 'r', encoding='utf-8') as f:


### PR DESCRIPTION
## Summary
- Initialize `text` to avoid UnboundLocalError when no legal document is selected.

## Testing
- `pytest`
- `pip install flask` *(fails: Could not find a version that satisfies the requirement flask)*

------
https://chatgpt.com/codex/tasks/task_e_689d217ec6dc8324a28a09fe3a6a87f8