### PR TITLE
Exclude legal documents from legislation view

### DIFF
--- a/app.py
+++ b/app.py
@@ -633,19 +633,14 @@ def parse_decision_route():
     return render_template('decision.html', result_json=None)
 
 
-def _collect_documents() -> dict[str, dict[str, str]]:
-    """Return mapping of base names to structure and NER paths."""
+def _collect_legislation_documents() -> dict[str, dict[str, str]]:
+    """Return mapping of legislation base names to structure and NER paths."""
     docs: dict[str, dict[str, str]] = {}
     if os.path.isdir('output'):
         for f in os.listdir('output'):
             if f.endswith('.json'):
                 base = f.rsplit('.', 1)[0]
                 docs.setdefault(base, {})['structure'] = os.path.join('output', f)
-    if os.path.isdir('legal_output'):
-        for f in os.listdir('legal_output'):
-            if f.endswith('.json'):
-                base = f.rsplit('.', 1)[0]
-                docs.setdefault(base, {})['structure'] = os.path.join('legal_output', f)
     if os.path.isdir('ner_output'):
         for f in os.listdir('ner_output'):
             if f.endswith('_ner.json'):
@@ -770,7 +765,7 @@ def _save_annotation(
 
 @app.route('/legislation')
 def view_legislation():
-    docs = _collect_documents()
+    docs = _collect_legislation_documents()
     files = sorted(docs.keys())
     name = request.args.get('file')
     data = None
@@ -911,7 +906,7 @@ def view_legal_documents():
 
 @app.route('/legislation/edit', methods=['GET', 'POST'])
 def edit_legislation():
-    docs = _collect_documents()
+    docs = _collect_legislation_documents()
     name = request.args.get('file')
     if name not in docs:
         return "File not found", 404

--- a/tests/test_view_legislation_excludes_legal.py
+++ b/tests/test_view_legislation_excludes_legal.py
@@ -1,0 +1,20 @@
+import json
+import pytest
+
+flask = pytest.importorskip('flask')
+
+
+def test_view_legislation_excludes_legal_documents(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    out_dir = tmp_path / 'output'
+    legal_dir = tmp_path / 'legal_output'
+    out_dir.mkdir()
+    legal_dir.mkdir()
+    (out_dir / 'law.json').write_text(json.dumps({}), encoding='utf-8')
+    (legal_dir / 'case.json').write_text(json.dumps({}), encoding='utf-8')
+    import app as app_mod
+    client = app_mod.app.test_client()
+    res = client.get('/legislation')
+    body = res.get_data(as_text=True)
+    assert 'law' in body
+    assert 'case' not in body


### PR DESCRIPTION
## Summary
- Separate collection of Moroccan legislation files from generic legal documents
- Show only structured legislation in `/legislation` view
- Cover exclusion logic with a regression test

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689d28f76f188324b14ab6a6fcd02a08