### PR TITLE
Enable editing for legal documents

### DIFF
--- a/templates/legal_documents.html
+++ b/templates/legal_documents.html
@@ -31,8 +31,7 @@
 </section>
 {% endif %}
 <section class="card">
-    <a class="button" href="{{ url_for('edit_legislation', file=selected) }}">Edit annotations</a>
-    <a class="button" href="{{ url_for('edit_decision', file=selected) }}">Edit decisions</a>
+    <a class="button" href="{{ url_for('edit_legal_document', file=selected) }}">Edit annotations</a>
 </section>
 <div id="popup" style="display:none;position:fixed;top:10%;left:10%;width:80%;max-height:80%;overflow:auto;background:white;border:1px solid #888;padding:10px;z-index:1000;">
     <button id="popup-close" style="float:left;">X</button>


### PR DESCRIPTION
## Summary
- Avoid listing legal documents on the Moroccan legislation page by ignoring NER-only files when collecting legislation
- Introduce shared document editing helper and route for legal documents
- Update legal documents template to use the new editing route

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689d2aac30648324b11f1132b73b58fc