### PR TITLE
Restore decision editing for legal documents

### DIFF
--- a/app.py
+++ b/app.py
@@ -1070,10 +1070,14 @@ def edit_legal_document():
 
 @app.route('/decision/edit', methods=['GET', 'POST'])
 def edit_decision():
-    """Edit court decision documents (alias for edit_legislation)."""
+    """Edit court decision documents from either source."""
     docs = _collect_legislation_documents()
+    legal_docs = _collect_legal_documents()
+    for k, v in legal_docs.items():
+        docs.setdefault(k, {})['structure'] = v
     name = request.args.get('file')
-    return _edit_document(docs, name, 'view_legislation')
+    view = 'view_legal_documents' if name in legal_docs else 'view_legislation'
+    return _edit_document(docs, name, view)
 
 
 @app.route('/query', methods=['GET', 'POST'])

--- a/templates/legal_documents.html
+++ b/templates/legal_documents.html
@@ -32,6 +32,7 @@
 {% endif %}
 <section class="card">
     <a class="button" href="{{ url_for('edit_legal_document', file=selected) }}">Edit annotations</a>
+    <a class="button" href="{{ url_for('edit_decision', file=selected) }}">Edit decisions</a>
 </section>
 <div id="popup" style="display:none;position:fixed;top:10%;left:10%;width:80%;max-height:80%;overflow:auto;background:white;border:1px solid #888;padding:10px;z-index:1000;">
     <button id="popup-close" style="float:left;">X</button>


### PR DESCRIPTION
## Summary
- Add missing "Edit decisions" button on legal documents page
- Allow `/decision/edit` route to load decision data from `legal_output` files as well as legislation

## Testing
- `pytest`
- `pytest tests/test_edit_decision_sections.py -q` *(skipped: missing Flask dependency)*


------
https://chatgpt.com/codex/tasks/task_e_689d2cdd2fe483249ae6b2bdf4326ad5