### PR TITLE
Add PostgreSQL backend and SQLAlchemy engine

### DIFF
--- a/crossref_postgres.py
+++ b/crossref_postgres.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+import os, re
+from functools import lru_cache
+from typing import Optional, List, Dict, Any
+from sqlalchemy import create_engine, text
+from sqlalchemy.pool import QueuePool
+
+PG_DSN = os.environ.get("PG_DSN", "postgresql+psycopg://postgres:postgres@localhost:5432/legislation")
+engine = create_engine(PG_DSN, poolclass=QueuePool, pool_size=10, max_overflow=20)
+
+_DIGIT_TRANS = str.maketrans("٠١٢٣٤٥٦٧٨٩", "0123456789")
+def canonical_num(value: str) -> Optional[str]:
+    if not isinstance(value, str):
+        return None
+    s = value.translate(_DIGIT_TRANS)
+    m = re.search(r"\d+(?:[./]+[^\d]*\d+)*", s)
+    if not m:
+        return None
+    digits = re.findall(r"\d+", m.group(0))
+    seps   = re.findall(r"[./]+", m.group(0))
+    out = digits[0]
+    for sep, d in zip(seps, digits[1:]):
+        out += sep[0] + d
+    return out
+
+@lru_cache(maxsize=8192)
+def get_article_hits(article_number_raw: str, law_number_raw: Optional[str] = None, limit: int = 5) -> List[Dict[str, Any]]:
+    art = canonical_num(article_number_raw or "")
+    law = canonical_num(law_number_raw) if law_number_raw else None
+    if not art:
+        return []
+    with engine.connect() as conn:
+        hits: List[Dict[str, Any]] = []
+        if law:
+            rows = conn.execute(text("""
+                SELECT a.text, a.number, d.id, d.file_name, d.short_title, d.doc_number
+                FROM articles a JOIN documents d ON d.id=a.document_id
+                WHERE d.doc_number=:law AND a.number=:art
+                LIMIT :lim
+            """), dict(law=law, art=art, lim=limit)).mappings().all()
+            hits.extend([
+                {
+                    "document_id": r["id"], "file_name": r["file_name"], "short_title": r["short_title"],
+                    "doc_number": r["doc_number"], "article_number": r["number"], "text": r["text"]
+                } for r in rows
+            ])
+        if len(hits) < limit:
+            rows = conn.execute(text("""
+                SELECT a.text, a.number, d.id, d.file_name, d.short_title, d.doc_number
+                FROM articles a JOIN documents d ON d.id=a.document_id
+                WHERE a.number=:art
+                ORDER BY d.doc_number NULLS LAST, d.id
+                LIMIT :lim
+            """), dict(art=art, lim=limit)).mappings().all()
+            seen = {(h["document_id"], h["article_number"]) for h in hits}
+            for r in rows:
+                key = (r["id"], r["number"])
+                if key in seen:
+                    continue
+                hits.append({
+                    "document_id": r["id"], "file_name": r["file_name"], "short_title": r["short_title"],
+                    "doc_number": r["doc_number"], "article_number": r["number"], "text": r["text"]
+                })
+                if len(hits) >= limit:
+                    break
+        return hits
+
+@lru_cache(maxsize=4096)
+def find_person_docs(normalized_name: str, limit: int = 200) -> List[Dict[str, Any]]:
+    if not normalized_name:
+        return []
+    with engine.connect() as conn:
+        rows = conn.execute(text("""
+            SELECT DISTINCT d.id, d.file_name, d.short_title, d.doc_number
+            FROM entities e JOIN documents d ON d.id=e.document_id
+            WHERE e.type='PERSON' AND e.normalized=:n
+            LIMIT :lim
+        """), dict(n=normalized_name, lim=limit)).mappings().all()
+        return [{"document_id": r["id"], "file_name": r["file_name"],
+                 "short_title": r["short_title"], "doc_number": r["doc_number"]} for r in rows]
+
+def format_article_popup(hit: Dict[str, Any]) -> str:
+    title = hit.get("short_title") or hit.get("file_name") or f"Doc {hit.get('document_id')}"
+    num   = hit.get("article_number","")
+    text  = (hit.get("text") or "").replace("\n"," ").strip()
+    text  = re.sub(r"<([^,<>]+), id:[^>]+>", r" \1 ", text)
+    return f"<b>{title} — الفصل {num}</b><br>{text}"

--- a/db/postgres_import.py
+++ b/db/postgres_import.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+import json, os, glob
+from typing import Dict, Any
+from sqlalchemy import create_engine, text
+from sqlalchemy.pool import QueuePool
+
+PG_DSN = os.environ.get("PG_DSN", "postgresql+psycopg://postgres:postgres@localhost:5432/legislation")
+engine = create_engine(PG_DSN, poolclass=QueuePool, pool_size=10, max_overflow=20)
+
+def upsert_document(conn, file_name, short_title, doc_number):
+    r = conn.execute(text("""
+        INSERT INTO documents(file_name, short_title, doc_number)
+        VALUES (:f,:s,:n)
+        ON CONFLICT (file_name) DO UPDATE SET short_title=EXCLUDED.short_title, doc_number=EXCLUDED.doc_number
+        RETURNING id
+    """), dict(f=file_name, s=short_title, n=doc_number)).first()
+    return r[0]
+
+def import_json_dir(path: str):
+    with engine.begin() as conn:
+        for p in glob.glob(os.path.join(path, "*.json")):
+            data = json.load(open(p, "r", encoding="utf-8"))
+            meta  = data.get("metadata", {})
+            short = meta.get("short_title") or meta.get("official_title") or os.path.basename(p)
+            docn  = meta.get("document_number") or meta.get("number")
+            doc_id = upsert_document(conn, os.path.basename(p), short, docn)
+
+            conn.execute(text("DELETE FROM articles WHERE document_id=:d"), dict(d=doc_id))
+            for node in data.get("structure", []):
+                if node.get("type") == "ARTICLE":
+                    conn.execute(text("""
+                        INSERT INTO articles(document_id, number, text)
+                        VALUES (:d, :n, :t)
+                    """), dict(d=doc_id, n=node.get("number") or node.get("normalized") or node.get("title"), t=node.get("text") or ""))
+
+            ents = data.get("ner_result", {}).get("entities", [])
+            conn.execute(text("DELETE FROM entities WHERE document_id=:d"), dict(d=doc_id))
+            for e in ents:
+                conn.execute(text("""
+                    INSERT INTO entities(document_id, type, text, normalized)
+                    VALUES (:d, :ty, :tx, :nz)
+                """), dict(d=doc_id, ty=e.get("type"), tx=e.get("text"), nz=e.get("normalized") or e.get("text")))
+
+            rels = data.get("ner_result", {}).get("relations", [])
+            conn.execute(text("DELETE FROM relations WHERE document_id=:d"), dict(d=doc_id))
+            for r in rels:
+                conn.execute(text("""
+                    INSERT INTO relations(document_id, source_id, target_id, type)
+                    VALUES (:d, :s, :t, :ty)
+                """), dict(d=doc_id, s=r.get("source_id"), t=r.get("target_id"), ty=r.get("type")))

--- a/db/schema_postgres.sql
+++ b/db/schema_postgres.sql
@@ -1,0 +1,35 @@
+CREATE TABLE IF NOT EXISTS documents (
+  id SERIAL PRIMARY KEY,
+  file_name TEXT UNIQUE,
+  short_title TEXT,
+  doc_number TEXT,
+  created_at TIMESTAMPTZ DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS articles (
+  id SERIAL PRIMARY KEY,
+  document_id INT REFERENCES documents(id) ON DELETE CASCADE,
+  number TEXT,
+  text   TEXT
+);
+
+CREATE TABLE IF NOT EXISTS entities (
+  id SERIAL PRIMARY KEY,
+  document_id INT REFERENCES documents(id) ON DELETE CASCADE,
+  type TEXT,
+  text TEXT,
+  normalized TEXT
+);
+
+CREATE TABLE IF NOT EXISTS relations (
+  id SERIAL PRIMARY KEY,
+  document_id INT REFERENCES documents(id) ON DELETE CASCADE,
+  source_id INT,
+  target_id INT,
+  type TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_doc_docnum      ON documents(doc_number);
+CREATE INDEX IF NOT EXISTS idx_article_doc_num ON articles(document_id, number);
+CREATE INDEX IF NOT EXISTS idx_entity_norm     ON entities(normalized, type);
+CREATE INDEX IF NOT EXISTS idx_entity_doc      ON entities(document_id);

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,13 @@
+version: "3.9"
+services:
+  postgres:
+    image: pgvector/pgvector:pg16
+    environment:
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_USER: postgres
+      POSTGRES_DB: legislation
+    ports: ["5432:5432"]
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+volumes:
+  pgdata:

--- a/tests/test_home_query.py
+++ b/tests/test_home_query.py
@@ -3,6 +3,7 @@ import pytest
 
 flask = pytest.importorskip('flask')
 
+
 def test_home_sql_query(tmp_path, monkeypatch):
     db = tmp_path / 'test.db'
     con = sqlite3.connect(db)
@@ -11,7 +12,7 @@ def test_home_sql_query(tmp_path, monkeypatch):
     cur.execute('INSERT INTO t (id) VALUES (1)')
     con.commit()
     con.close()
-    monkeypatch.setenv('DB_PATH', str(db))
+    monkeypatch.setenv('DB_DSN', f'sqlite:///{db}')
     import importlib
     import app as app_mod
     importlib.reload(app_mod)


### PR DESCRIPTION
## Summary
- replace SQLite cross-references with a PostgreSQL-backed `crossref_postgres` module using SQLAlchemy
- add PostgreSQL schema and importer utility plus Docker compose file for pgvector
- update app and tests to rely on SQLAlchemy connections instead of a SQLite path

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689d3f5c8f08832499957ab006c88177