### PR TITLE
Keep NER output separate when importing documents

### DIFF
--- a/app.py
+++ b/app.py
@@ -403,12 +403,16 @@ def home():
                             json.dump(ner_saved, f, ensure_ascii=False, indent=2)
                     saved_file = base
                     saved_to = output_type
-                    if output_type == 'legislation':
-                        try:  # pragma: no cover - optional dependency
-                            from db.postgres_import import import_json_dir
-                            import_json_dir("output")
-                        except Exception as exc:
-                            process_error = str(exc)
+                    try:  # pragma: no cover - optional dependency
+                        from db.postgres_import import import_json_dir
+                        if os.path.isdir('output'):
+                            import_json_dir('output')
+                        if os.path.isdir('legal_output'):
+                            import_json_dir('legal_output')
+                        if os.path.isdir('ner_output'):
+                            import_json_dir('ner_output')
+                    except Exception as exc:
+                        process_error = str(exc)
                 except Exception as exc:  # pragma: no cover - show error
                     process_error = str(exc)
                 finally:

--- a/db/postgres_import.py
+++ b/db/postgres_import.py
@@ -20,31 +20,86 @@ def import_json_dir(path: str):
     with engine.begin() as conn:
         for p in glob.glob(os.path.join(path, "*.json")):
             data = json.load(open(p, "r", encoding="utf-8"))
-            meta  = data.get("metadata", {})
-            short = meta.get("short_title") or meta.get("official_title") or os.path.basename(p)
-            docn  = meta.get("document_number") or meta.get("number")
-            doc_id = upsert_document(conn, os.path.basename(p), short, docn)
-
-            conn.execute(text("DELETE FROM articles WHERE document_id=:d"), dict(d=doc_id))
-            for node in data.get("structure", []):
-                if node.get("type") == "ARTICLE":
-                    conn.execute(text("""
+            file_name = os.path.basename(p)
+            if file_name.endswith("_ner.json") and "metadata" not in data:
+                base_file = file_name.replace("_ner", "")
+                row = conn.execute(
+                    text("SELECT id FROM documents WHERE file_name=:f"),
+                    {"f": base_file},
+                ).first()
+                if not row:
+                    continue
+                doc_id = row[0]
+            else:
+                meta = data.get("metadata", {})
+                short = (
+                    meta.get("short_title")
+                    or meta.get("official_title")
+                    or file_name
+                )
+                docn = meta.get("document_number") or meta.get("number")
+                doc_id = upsert_document(conn, file_name, short, docn)
+                conn.execute(
+                    text("DELETE FROM articles WHERE document_id=:d"),
+                    {"d": doc_id},
+                )
+                for node in data.get("structure", []):
+                    if node.get("type") == "ARTICLE":
+                        conn.execute(
+                            text(
+                                """
                         INSERT INTO articles(document_id, number, text)
                         VALUES (:d, :n, :t)
-                    """), dict(d=doc_id, n=node.get("number") or node.get("normalized") or node.get("title"), t=node.get("text") or ""))
+                    """
+                            ),
+                            {
+                                "d": doc_id,
+                                "n": node.get("number")
+                                or node.get("normalized")
+                                or node.get("title"),
+                                "t": node.get("text") or "",
+                            },
+                        )
 
-            ents = data.get("ner_result", {}).get("entities", [])
-            conn.execute(text("DELETE FROM entities WHERE document_id=:d"), dict(d=doc_id))
+            ner_root = data.get("ner_result") or data
+            ents = ner_root.get("entities", [])
+            conn.execute(
+                text("DELETE FROM entities WHERE document_id=:d"),
+                {"d": doc_id},
+            )
             for e in ents:
-                conn.execute(text("""
+                conn.execute(
+                    text(
+                        """
                     INSERT INTO entities(document_id, type, text, normalized)
                     VALUES (:d, :ty, :tx, :nz)
-                """), dict(d=doc_id, ty=e.get("type"), tx=e.get("text"), nz=e.get("normalized") or e.get("text")))
+                """
+                    ),
+                    {
+                        "d": doc_id,
+                        "ty": e.get("type"),
+                        "tx": e.get("text"),
+                        "nz": e.get("normalized") or e.get("text"),
+                    },
+                )
 
-            rels = data.get("ner_result", {}).get("relations", [])
-            conn.execute(text("DELETE FROM relations WHERE document_id=:d"), dict(d=doc_id))
+            rels = ner_root.get("relations", [])
+            conn.execute(
+                text("DELETE FROM relations WHERE document_id=:d"),
+                {"d": doc_id},
+            )
             for r in rels:
-                conn.execute(text("""
+                conn.execute(
+                    text(
+                        """
                     INSERT INTO relations(document_id, source_id, target_id, type)
                     VALUES (:d, :s, :t, :ty)
-                """), dict(d=doc_id, s=r.get("source_id"), t=r.get("target_id"), ty=r.get("type")))
+                """
+                    ),
+                    {
+                        "d": doc_id,
+                        "s": r.get("source_id"),
+                        "t": r.get("target_id"),
+                        "ty": r.get("type"),
+                    },
+                )

--- a/tests/test_save_output_type.py
+++ b/tests/test_save_output_type.py
@@ -62,7 +62,7 @@ def test_save_output_type(tmp_path, monkeypatch):
     assert plain_json.exists()
     plain_saved = json.loads(plain_json.read_text(encoding='utf-8'))
     assert 'decision' not in plain_saved
-    assert 'ner' not in plain_saved
+    assert 'ner_result' not in plain_saved
     assert not (tmp_path / 'ner_output' / 'plain_ner.json').exists()
     assert calls['ner'] == 0
     assert calls['decision'] == 0
@@ -82,7 +82,7 @@ def test_save_output_type(tmp_path, monkeypatch):
     assert saved['text'] == 'data'
     assert saved['structure'] == [{'text': 'data'}]
     assert saved['decision'] == {'case': 1}
-    assert 'ner' not in saved
+    assert 'ner_result' not in saved
     assert (tmp_path / 'ner_output' / 'doc_ner.json').exists()
     assert not (tmp_path / 'output' / 'doc.json').exists()
     assert calls['run_passes'] == 1


### PR DESCRIPTION
## Summary
- Stop embedding structured NER data in document JSON and save it only in `ner_output`
- Import standalone NER files into PostgreSQL by linking them to existing documents

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689d41b3ee3483248cf2aeca72a873dc