### PR TITLE
Replace deprecated Flask hook to fix startup

### DIFF
--- a/app.py
+++ b/app.py
@@ -58,7 +58,9 @@ except BaseException:  # pragma: no cover - missing dependency
 app = Flask(__name__)
 
 
-@app.before_first_request
+# Flask 3 removed ``before_first_request``. ``before_serving`` runs once per
+# process before handling the first request and is the closest replacement.
+@app.before_serving
 def _init_import_watcher() -> None:
     """Import existing JSON files and start directory watchers."""
     try:


### PR DESCRIPTION
## Summary
- Update app initialization to use `before_serving` in place of removed `before_first_request`
- Clarify behavior of the initialization hook in code comments

## Testing
- `pytest`
- ⚠️ `python app.py` (missing dependency: SQLAlchemy)


------
https://chatgpt.com/codex/tasks/task_e_68a7444a45808324a5a34e64ca1def7e