### PR TITLE
Handle removed Flask before_first_request hook

### DIFF
--- a/app.py
+++ b/app.py
@@ -60,7 +60,12 @@ app = Flask(__name__)
 # ``before_first_request`` was removed in Flask 3.0, while older Flask
 # versions do not provide ``before_serving``. Pick whichever hook exists so
 # that the initial import runs once on startup across supported versions.
-init_hook = getattr(app, "before_serving", app.before_first_request)
+# Using ``getattr`` with a nested fallback avoids eager attribute access
+# errors when running under Flask 3 where ``before_first_request`` no longer
+# exists.
+init_hook = getattr(app, "before_serving", None) or getattr(
+    app, "before_first_request", lambda f: f
+)
 
 
 @init_hook


### PR DESCRIPTION
## Summary
- Avoid eager access to `before_first_request`, using a fallback when initializing server hooks to support Flask 3

## Testing
- `pytest`
- `python3 app.py` *(fails: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68a7495cc49483249acc04f346f1d62a