### PR TITLE
Improve sync error visibility

### DIFF
--- a/app.py
+++ b/app.py
@@ -459,6 +459,7 @@ def sync_db():
         from db.postgres_import import import_paths
         import_paths(['output', 'legal_output', 'ner_output'])
     except Exception as exc:  # pragma: no cover - optional database
+        app.logger.exception("Sync failed")
         msg = f'Sync failed: {exc}'
         status = 500
     return msg, status

--- a/static/ui.js
+++ b/static/ui.js
@@ -102,8 +102,8 @@
     toast.className = 'toast';
     toast.textContent = msg;
     container.appendChild(toast);
-    setTimeout(() => toast.classList.add('hide'), 10);
-    setTimeout(() => toast.remove(), 3100);
+    setTimeout(() => toast.classList.add('hide'), 3000);
+    setTimeout(() => toast.remove(), 3300);
   };
 
   // Help modal


### PR DESCRIPTION
## Summary
- Keep toast notifications visible for ~3 seconds
- Log sync_db failures to help diagnose database issues

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a74db0e90c8324836b44e875494754