### PR TITLE
Use OS user for default PostgreSQL DSN

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,9 @@ python db/postgres_import.py           # imports from output/ and legal_output/
 ```
 
 Set the `PG_DSN` environment variable to point at your PostgreSQL server
-if it differs from the default `postgresql+psycopg://postgres:postgres@localhost:5432/legislation`.
+if it differs from the default `postgresql+psycopg:///legislation`.
+The default relies on peer authentication with the current operating system
+user; include a username and password in the DSN if your setup requires them.
 
 Once the data is loaded, the `crossref_postgres.py` module provides helper
 functions such as `get_article_hits` and `find_person_docs` to resolve cross

--- a/app.py
+++ b/app.py
@@ -92,7 +92,7 @@ def inject_globals() -> dict:
 
 # Database connection string
 DB_DSN = os.environ.get(
-    "DB_DSN", "postgresql+psycopg://postgres:postgres@localhost:5432/legislation"
+    "DB_DSN", "postgresql+psycopg:///legislation"
 )
 engine = create_engine(DB_DSN)
 

--- a/crossref_postgres.py
+++ b/crossref_postgres.py
@@ -14,7 +14,7 @@ from sqlalchemy import create_engine, text
 from sqlalchemy.pool import QueuePool
 
 PG_DSN = os.environ.get(
-    "PG_DSN", "postgresql+psycopg://postgres:postgres@localhost:5432/legislation"
+    "PG_DSN", "postgresql+psycopg:///legislation"
 )
 engine = create_engine(PG_DSN, poolclass=QueuePool, pool_size=10, max_overflow=20)
 

--- a/db/postgres_import.py
+++ b/db/postgres_import.py
@@ -25,7 +25,7 @@ except Exception:  # pragma: no cover - watchdog not installed
     Observer = None
 
 PG_DSN = os.environ.get(
-    "PG_DSN", "postgresql+psycopg://postgres:postgres@localhost:5432/legislation"
+    "PG_DSN", "postgresql+psycopg:///legislation"
 )
 engine = create_engine(PG_DSN, poolclass=QueuePool, pool_size=10, max_overflow=20)
 


### PR DESCRIPTION
## Summary
- Default PostgreSQL DSN now connects via local user rather than hard‑coded `postgres` credentials
- Document environment variable behaviour and peer authentication in README

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a7548e8eb4832486d1966397274f4f