### PR TITLE
Ensure database tables exist before syncing

### DIFF
--- a/app.py
+++ b/app.py
@@ -456,7 +456,8 @@ def sync_db():
     msg = 'Database synchronised'
     status = 200
     try:
-        from db.postgres_import import import_paths
+        from db.postgres_import import import_paths, init_db
+        init_db()
         import_paths(['output', 'legal_output', 'ner_output'])
     except Exception as exc:  # pragma: no cover - optional database
         app.logger.exception("Sync failed")


### PR DESCRIPTION
## Summary
- Ensure `/sync_db` route initializes PostgreSQL schema before importing JSON files

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a7560225f08324b80cce4655aacaf2