### PR TITLE
feat: add global ids for cross-document references

### DIFF
--- a/db/postgres_import.py
+++ b/db/postgres_import.py
@@ -108,8 +108,8 @@ def _import_file(conn, p: str) -> None:
         conn.execute(
             text(
                 """
-            INSERT INTO entities(document_id, type, text, normalized)
-            VALUES (:d, :ty, :tx, :nz)
+            INSERT INTO entities(document_id, type, text, normalized, global_id)
+            VALUES (:d, :ty, :tx, :nz, :gid)
         """
             ),
             {
@@ -117,6 +117,7 @@ def _import_file(conn, p: str) -> None:
                 "ty": e.get("type"),
                 "tx": e.get("text"),
                 "nz": e.get("normalized") or e.get("text"),
+                "gid": e.get("global_id"),
             },
         )
 

--- a/db/schema_postgres.sql
+++ b/db/schema_postgres.sql
@@ -18,7 +18,8 @@ CREATE TABLE IF NOT EXISTS entities (
   document_id INT REFERENCES documents(id) ON DELETE CASCADE,
   type TEXT,
   text TEXT,
-  normalized TEXT
+  normalized TEXT,
+  global_id TEXT
 );
 
 CREATE TABLE IF NOT EXISTS relations (
@@ -33,3 +34,4 @@ CREATE INDEX IF NOT EXISTS idx_doc_docnum      ON documents(doc_number);
 CREATE INDEX IF NOT EXISTS idx_article_doc_num ON articles(document_id, number);
 CREATE INDEX IF NOT EXISTS idx_entity_norm     ON entities(normalized, type);
 CREATE INDEX IF NOT EXISTS idx_entity_doc      ON entities(document_id);
+CREATE INDEX IF NOT EXISTS idx_entity_gid      ON entities(global_id);

--- a/import_db.py
+++ b/import_db.py
@@ -55,6 +55,7 @@ def init_db(path: str) -> None:
             end_char INTEGER,
             normalized TEXT,
             canonical_num TEXT,
+            global_id TEXT,
             FOREIGN KEY(document_id) REFERENCES Documents(id)
         );
 
@@ -123,7 +124,7 @@ def import_json(db_path: str, dir_path: str = OUTPUT_DIR) -> None:
 
         for ent in data.get("entities", []):
             cur.execute(
-                "INSERT INTO Entities(document_id, ent_id, type, text, start_char, end_char, normalized, canonical_num) VALUES (?,?,?,?,?,?,?,?)",
+                "INSERT INTO Entities(document_id, ent_id, type, text, start_char, end_char, normalized, canonical_num, global_id) VALUES (?,?,?,?,?,?,?,?,?)",
                 (
                     doc_id,
                     ent.get("id"),
@@ -133,6 +134,7 @@ def import_json(db_path: str, dir_path: str = OUTPUT_DIR) -> None:
                     ent.get("end_char"),
                     ent.get("normalized"),
                     canonical_num(ent.get("normalized") or ent.get("text")),
+                    ent.get("global_id"),
                 ),
             )
         for rel in data.get("relations", []):
@@ -153,6 +155,7 @@ def import_json(db_path: str, dir_path: str = OUTPUT_DIR) -> None:
         CREATE INDEX IF NOT EXISTS idx_articles_docid_number ON Articles(document_id, number);
         CREATE INDEX IF NOT EXISTS idx_entities_norm_type ON Entities(normalized, type);
         CREATE INDEX IF NOT EXISTS idx_entities_docid ON Entities(document_id);
+        CREATE INDEX IF NOT EXISTS idx_entities_global_id ON Entities(global_id);
         """
     )
     con.commit()

--- a/tests/test_global_ids.py
+++ b/tests/test_global_ids.py
@@ -1,0 +1,61 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from ner import postprocess_result
+
+
+def test_global_ids_for_law_and_article():
+    text = "المادة 7 من القانون رقم 37.22"
+    result = {
+        "entities": [
+            {"id": "a", "type": "ARTICLE", "text": "المادة 7", "start_char": 0, "end_char": 8},
+            {"id": "b", "type": "LAW", "text": "القانون رقم 37.22", "start_char": 13, "end_char": 32},
+        ],
+        "relations": [
+            {"relation_id": "r", "type": "refers_to", "source_id": "a", "target_id": "b"},
+        ],
+    }
+    postprocess_result(text, result)
+    article = next(e for e in result["entities"] if e["type"] == "ARTICLE")
+    law = next(e for e in result["entities"] if e["type"] == "LAW")
+    assert law["global_id"] == "LAW_37.22"
+    assert article["global_id"] == "LAW_37.22_ART_7"
+
+
+def test_article_without_law_gets_simple_global_id():
+    text = "تنص المادة 5 على ..."
+    result = {
+        "entities": [
+            {"id": "1", "type": "ARTICLE", "text": "المادة 5", "start_char": 4, "end_char": 12}
+        ],
+        "relations": [],
+    }
+    postprocess_result(text, result)
+    art = result["entities"][0]
+    assert art["global_id"] == "ART_5"
+
+
+def test_article_refers_to_dahir():
+    text = "المادة 7 من الظهير الشريف رقم 1.23.60"
+    result = {
+        "entities": [
+            {"id": "a", "type": "ARTICLE", "text": "المادة 7", "start_char": 0, "end_char": 8},
+            {
+                "id": "b",
+                "type": "DAHIR",
+                "text": "الظهير الشريف رقم 1.23.60",
+                "start_char": 13,
+                "end_char": 41,
+            },
+        ],
+        "relations": [
+            {"relation_id": "r", "type": "refers_to", "source_id": "a", "target_id": "b"}
+        ],
+    }
+    postprocess_result(text, result)
+    art = next(e for e in result["entities"] if e["type"] == "ARTICLE")
+    law = next(e for e in result["entities"] if e["type"] == "DAHIR")
+    assert law["global_id"] == "DAHIR_1.23.60"
+    assert art["global_id"] == "DAHIR_1.23.60_ART_7"

--- a/tests/test_import_db_global_id.py
+++ b/tests/test_import_db_global_id.py
@@ -1,0 +1,31 @@
+import json
+import sqlite3
+from import_db import init_db, import_json
+from crossref import find_entity_docs
+
+
+def test_import_db_stores_global_id(tmp_path):
+    db_path = tmp_path / "test.sqlite"
+    init_db(str(db_path))
+    data_dir = tmp_path / "out"
+    data_dir.mkdir()
+    sample = {
+        "metadata": {},
+        "entities": [
+            {
+                "id": "E1",
+                "type": "LAW",
+                "text": "القانون رقم 37.22",
+                "normalized": "37.22 القانون",
+                "global_id": "LAW_37.22",
+            }
+        ],
+    }
+    (data_dir / "doc.json").write_text(json.dumps(sample, ensure_ascii=False), encoding="utf-8")
+    import_json(str(db_path), str(data_dir))
+    con = sqlite3.connect(str(db_path))
+    row = con.execute("SELECT global_id FROM Entities WHERE ent_id='E1'").fetchone()
+    con.close()
+    assert row[0] == "LAW_37.22"
+    docs = find_entity_docs("LAW_37.22", db_path=str(db_path))
+    assert docs and docs[0]["document_id"] == 1


### PR DESCRIPTION
## Summary
- persist NER-derived `global_id` values to SQLite and PostgreSQL for cross-document entity linking
- expose helpers in crossref modules to resolve documents by `global_id`
- add regression test ensuring `global_id` values are stored and queryable
- simplify global ID generation by preserving numeric separators and hashing non-law entities for robustness
- preserve law type in article IDs so dahirs, decrees, and constitutions remain distinct

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a88489bf2c8324a0300e70578408e6