### PR TITLE
Ensure PostgreSQL schema adds missing global_id column

### DIFF
--- a/db/postgres_import.py
+++ b/db/postgres_import.py
@@ -35,9 +35,9 @@ def init_db() -> None:
     schema_path = Path(__file__).with_name("schema_postgres.sql")
     ddl = schema_path.read_text(encoding="utf-8")
     with engine.begin() as conn:
+        # ``schema_postgres.sql`` now ensures the ``global_id`` column and index
+        # exist even for databases created with an older schema.
         conn.execute(text(ddl))
-        conn.execute(text("ALTER TABLE entities ADD COLUMN IF NOT EXISTS global_id TEXT"))
-        conn.execute(text("CREATE INDEX IF NOT EXISTS idx_entity_gid ON entities(global_id)"))
 
 
 def upsert_document(conn, file_name, short_title, doc_number):

--- a/db/schema_postgres.sql
+++ b/db/schema_postgres.sql
@@ -30,6 +30,11 @@ CREATE TABLE IF NOT EXISTS relations (
   type TEXT
 );
 
+-- Ensure the ``global_id`` column exists for databases created with an older
+-- schema that lacked it. Adding it here allows the subsequent index creation
+-- to succeed even if the table already existed without the column.
+ALTER TABLE entities ADD COLUMN IF NOT EXISTS global_id TEXT;
+
 CREATE INDEX IF NOT EXISTS idx_doc_docnum      ON documents(doc_number);
 CREATE INDEX IF NOT EXISTS idx_article_doc_num ON articles(document_id, number);
 CREATE INDEX IF NOT EXISTS idx_entity_norm     ON entities(normalized, type);


### PR DESCRIPTION
## Summary
- add fallback in schema_postgres.sql to always include global_id column before creating its index
- simplify postgres_import.init_db to rely on updated schema

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a8a130fec483248b7e6319e114b59a