### PR TITLE
Remove stray route decorator causing TypeError

### DIFF
--- a/app.py
+++ b/app.py
@@ -891,7 +891,6 @@ def view_legislation():
     )
 
 
-@app.route('/legal_documents')
 def _law_hints_from_text(txt: str) -> tuple[list[str], list[str]]:
     """Extract possible law numbers and names from a snippet of text."""
     nums: list[str] = []


### PR DESCRIPTION
## Summary
- remove mistaken `@app.route` decorator from `_law_hints_from_text`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a8ae66895883249c68f9054f80c6fe