### PR TITLE
Handle mixed article-law references

### DIFF
--- a/db/schema_postgres.sql
+++ b/db/schema_postgres.sql
@@ -3,6 +3,7 @@ CREATE TABLE IF NOT EXISTS documents (
   file_name TEXT UNIQUE,
   short_title TEXT,
   doc_number TEXT,
+  law_number TEXT,
   created_at TIMESTAMPTZ DEFAULT now()
 );
 
@@ -34,8 +35,10 @@ CREATE TABLE IF NOT EXISTS relations (
 -- schema that lacked it. Adding it here allows the subsequent index creation
 -- to succeed even if the table already existed without the column.
 ALTER TABLE entities ADD COLUMN IF NOT EXISTS global_id TEXT;
+ALTER TABLE documents ADD COLUMN IF NOT EXISTS law_number TEXT;
 
 CREATE INDEX IF NOT EXISTS idx_doc_docnum      ON documents(doc_number);
+CREATE INDEX IF NOT EXISTS idx_doc_lawnum     ON documents(law_number);
 CREATE INDEX IF NOT EXISTS idx_article_doc_num ON articles(document_id, number);
 CREATE INDEX IF NOT EXISTS idx_entity_norm     ON entities(normalized, type);
 CREATE INDEX IF NOT EXISTS idx_entity_doc      ON entities(document_id);


### PR DESCRIPTION
## Summary
- Index a dedicated `law_number` alongside `doc_number` in the PostgreSQL schema for quicker lookups
- Import legislation JSON files and persist extracted law numbers so references like "30.09" can be resolved even when only the dahir number is stored
- Query `law_number` during article resolution, falling back to title search only when needed

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a9fb82fa588324a93d98beb2b052de