### PR TITLE
Handle article text for law entities

### DIFF
--- a/app.py
+++ b/app.py
@@ -1137,6 +1137,17 @@ def view_legal_documents():
                 article_entry = _resolve_article_text(num, law_nums, law_names)
                 if article_entry:
                     ent.setdefault('articles', []).append(article_entry)
+            # Handle LAW entities that directly mention an article number
+            for ent in ent_map.values():
+                if ent.get('type') != 'LAW':
+                    continue
+                parsed = parse_law_article_nums(ent)
+                if not parsed:
+                    continue
+                art_num, law_num = parsed
+                article_entry = _resolve_article_text(art_num, [law_num], [])
+                if article_entry:
+                    ent.setdefault('articles', []).append(article_entry)
             entities = list(ent_map.values())
     return render_template(
         'legal_documents.html',

--- a/tests/test_view_legal_documents.py
+++ b/tests/test_view_legal_documents.py
@@ -34,3 +34,40 @@ def test_view_legal_documents_lists_files(tmp_path, monkeypatch):
     assert 'Edit annotations' in body
     assert 'id:1' in body
     assert 'class="entity-link"' not in body
+
+
+def test_law_entity_with_article_popup(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    out = tmp_path / 'legal_output'
+    ner_dir = tmp_path / 'ner_output'
+    out.mkdir()
+    ner_dir.mkdir()
+    structure = {
+        'structure': [{'text': '<المادة 1 من القانون 30.09, id:1>'}],
+        'text': 'المادة 1 من القانون 30.09',
+    }
+    (out / 'case.json').write_text(
+        json.dumps(structure, ensure_ascii=False), encoding='utf-8'
+    )
+    ner_data = {
+        'entities': [
+            {
+                'id': 1,
+                'type': 'LAW',
+                'text': 'المادة 1 من القانون 30.09',
+                'normalized': 'المادة 1 القانون 30.09',
+            }
+        ],
+        'relations': [],
+    }
+    (ner_dir / 'case_ner.json').write_text(
+        json.dumps(ner_data, ensure_ascii=False), encoding='utf-8'
+    )
+    import app as app_mod
+    monkeypatch.setattr(
+        app_mod, '_resolve_article_text', lambda num, law_nums, law_names: f'snippet {num}'
+    )
+    client = app_mod.app.test_client()
+    res = client.get('/legal_documents?file=case')
+    body = res.get_data(as_text=True)
+    assert '"articles": ["snippet 1"]' in body


### PR DESCRIPTION
## Summary
- attach article popups to LAW entities that specify an article number
- add regression test ensuring LAW references expose article content

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68aa32d21e348324b7f5a20271b01dc3